### PR TITLE
refactor: 중앙관리형 디스패치 구조 전환

### DIFF
--- a/src/bot/episode-writer.ts
+++ b/src/bot/episode-writer.ts
@@ -1,20 +1,10 @@
 import fs from 'node:fs';
 import path from 'node:path';
 import { runHaiku } from '../utils/haiku.js';
+import { atomicWriteSync } from '../utils/fs.js';
 import type { Episode, ConversationMessage } from '../types.js';
 
 const MAX_EPISODE_LINES = 200;
-
-function atomicWriteSync(filePath: string, content: string): void {
-  const tmp = filePath + '.tmp';
-  try {
-    fs.writeFileSync(tmp, content);
-    fs.renameSync(tmp, filePath);
-  } catch (err) {
-    try { fs.unlinkSync(tmp); } catch {}
-    throw err;
-  }
-}
 
 // ---------------------------------------------------------------------------
 // writeEpisode — Haiku로 요약 생성 후 episodes.jsonl에 append

--- a/src/bot/identity.ts
+++ b/src/bot/identity.ts
@@ -1,5 +1,0 @@
-// Identity is now handled by each team having its own Discord bot.
-// Each team logs in with its own bot token and sends messages as itself.
-// No webhooks needed — messages come FROM each team's bot user.
-
-export {};

--- a/src/bot/memory-consolidator.ts
+++ b/src/bot/memory-consolidator.ts
@@ -1,21 +1,9 @@
 import fs from 'node:fs';
 import path from 'node:path';
 import { runHaiku } from '../utils/haiku.js';
+import { atomicWriteSync } from '../utils/fs.js';
 import { isBusy } from '../teams/concurrency.js';
 import type { TeamsConfig, Episode } from '../types.js';
-
-/** Atomic write: write to temp file then rename to avoid corruption on crash. */
-function atomicWriteSync(filePath: string, content: string): void {
-  const tmp = filePath + '.tmp';
-  try {
-    fs.writeFileSync(tmp, content);
-    fs.renameSync(tmp, filePath);
-  } catch (err) {
-    // Clean up temp file on failure
-    try { fs.unlinkSync(tmp); } catch {}
-    throw err;
-  }
-}
 
 const CONSOLIDATE_INTERVAL_MS = 6 * 60 * 60 * 1000; // 6 hours
 const SIZE_THRESHOLD_BYTES = 3 * 1024; // 3KB

--- a/src/utils/fs.ts
+++ b/src/utils/fs.ts
@@ -1,0 +1,13 @@
+import fs from 'node:fs';
+
+/** Atomic write: write to temp file then rename to avoid corruption on crash. */
+export function atomicWriteSync(filePath: string, content: string): void {
+  const tmp = filePath + '.tmp';
+  try {
+    fs.writeFileSync(tmp, content);
+    fs.renameSync(tmp, filePath);
+  } catch (err) {
+    try { fs.unlinkSync(tmp); } catch {}
+    throw err;
+  }
+}


### PR DESCRIPTION
## Summary
- 비리더 봇의 `dispatchMentionedTeams` 호출을 제거하고, 리더(대장코코)만 dispatch 권한을 갖도록 변경
- 비리더 출력의 멘션은 리더 inbox로 전달되어 리더가 중앙에서 dispatch 결정
- 레거시 `identity.ts` 삭제, `atomicWriteSync` 중복 코드를 `utils/fs.ts`로 추출

## Changes
### Phase 1: 중앙관리형 디스패치
- `client.ts`: `handleTeamInvocation`에서 리더/비리더 분기 — 리더만 `dispatchMentionedTeams` 호출
- `client.ts`: `dispatchMentionedTeams`를 리더 전용 함수로 정리 (불필요한 비리더→리더 inbox 분기 제거)

### Phase 2: 코드 리팩토링
- `identity.ts` 삭제 (빈 레거시 파일, import 없음)
- `utils/fs.ts` 신설 — `atomicWriteSync` 공유 유틸
- `episode-writer.ts`, `memory-consolidator.ts`에서 중복 `atomicWriteSync` 제거, 공유 유틸 import

## Architecture (Before → After)
```
Before: 모든 봇이 출력에서 멘션 감지 → 직접 dispatch
  리더 출력 → dispatchMentionedTeams → 대상 팀 invoke
  비리더 출력 → dispatchMentionedTeams → inbox-only (리더) / 직접 invoke (비리더)

After: 리더만 dispatch 권한
  리더 출력 → dispatchMentionedTeams → 대상 팀 invoke
  비리더 출력 → 리더 inbox에 기록 → 리더가 판단 후 dispatch
```

## Test plan
- [ ] 봇 실행 후 회장님→대장코코 메시지 시 정상 라우팅 확인
- [ ] 대장코코→BE코코 지시 시 BE코코 정상 invoke 확인
- [ ] BE코코 출력에서 대장코코 태그 시 리더 inbox로만 전달되는지 확인
- [ ] TypeScript 빌드 에러 없음 확인 (`npx tsc --noEmit`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)