### PR TITLE
fix: config/episode/client 안정성 개선 3건

### DIFF
--- a/src/bot/client.ts
+++ b/src/bot/client.ts
@@ -5,6 +5,7 @@ import {
   Client, GatewayIntentBits, REST, Routes, SlashCommandBuilder,
   type GuildMember, type TextChannel, type Message, type ChatInputCommandInteraction,
 } from 'discord.js';
+import { atomicWriteSync } from '../utils/fs.js';
 import { routeMessage, findMentionedTeams } from './router.js';
 import { invokeTeam } from '../teams/invoker.js';
 import { addMessage, getRecentConversation } from '../teams/context.js';
@@ -352,7 +353,7 @@ export async function createBots(config: TeamsConfig, env: EnvConfig): Promise<v
             const raw = JSON.parse(fs.readFileSync(teamsJsonPath, 'utf-8'));
             if (raw.teams[team.id]) {
               raw.teams[team.id].discordUserId = client.user.id;
-              fs.writeFileSync(teamsJsonPath, JSON.stringify(raw, null, 2) + '\n');
+              atomicWriteSync(teamsJsonPath, JSON.stringify(raw, null, 2) + '\n');
             }
           } catch (err) {
             console.warn(`[client] Failed to sync discordUserId for ${team.name}: ${err}`);

--- a/src/bot/episode-writer.ts
+++ b/src/bot/episode-writer.ts
@@ -98,7 +98,7 @@ export function loadRecentEpisodes(
         return null;
       }
       const ago = formatTimeAgo(Date.now() - ep.ts);
-      return `[${ago}] ${ep.summary} (ch:${ep.channelId})`;
+      return `[${ago}] ${ep.summary ?? '(no summary)'} (ch:${ep.channelId ?? 'unknown'})`;
     } catch {
       parseFailures++;
       if (!firstCorruptedSample) firstCorruptedSample = line.slice(0, 100);

--- a/src/config.ts
+++ b/src/config.ts
@@ -70,7 +70,7 @@ export function loadTeamsConfig(workspacePath: string = process.cwd()): TeamsCon
     teams[id] = {
       id,
       name: cfg.name,
-      color: parseInt(cfg.color.replace('#', ''), 16),
+      color: cfg.color ? parseInt(cfg.color.replace('#', ''), 16) : 0x808080,
       avatar: AVATAR_MAP[cfg.avatar] ?? cfg.avatar,
       engine: cfg.engine ?? 'claude',
       model: cfg.model ?? 'sonnet',


### PR DESCRIPTION
## Summary
- **config.ts**: `cfg.color` undefined 시 `TypeError` 방어 — `parseInt(undefined.replace(...))` 크래시 방지, 기본값 회색(`0x808080`) 적용
- **episode-writer.ts**: JSON 파싱 후 `summary`/`channelId` 필드 null 방어 — 손상된 에피소드 데이터에서도 안전하게 표시
- **client.ts**: `teams.json` 쓰기 시 `atomicWriteSync` 적용 — 쓰기 중 프로세스 크래시 시 파일 손상 방지 (기존 `fs.writeFileSync` → `atomicWriteSync`)

## Test plan
- [ ] TypeScript 빌드 통과 확인 (tsc --noEmit 에러 0건)
- [ ] teams.json에 color 없는 팀 설정 시 봇 정상 기동 확인
- [ ] 손상된 episodes.jsonl 라인에서 loadRecentEpisodes 정상 동작 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)