### PR TITLE
fix. 런타임 안전성 개선 — 요청/stdout 크기 제한, spawn 에러 처리

### DIFF
--- a/src/orchestrator/gemini-engine.ts
+++ b/src/orchestrator/gemini-engine.ts
@@ -5,18 +5,30 @@ export class GeminiEngine extends BaseEngine {
   private proc: ChildProcess | null = null;
 
   async start(): Promise<void> {
-    this.proc = spawn('gemini', [
-      '-p', this.opts.prompt,
-      '--model', this.opts.model,
-    ], {
-      cwd: this.opts.cwd,
-      env: this.getTeamEnv(),
-      stdio: ['ignore', 'pipe', 'pipe'],
-    });
+    try {
+      this.proc = spawn('gemini', [
+        '-p', this.opts.prompt,
+        '--model', this.opts.model,
+      ], {
+        cwd: this.opts.cwd,
+        env: this.getTeamEnv(),
+        stdio: ['ignore', 'pipe', 'pipe'],
+      });
+    } catch (err) {
+      this.emit('result', { type: 'result', result: `[GeminiEngine] spawn failed: ${err instanceof Error ? err.message : err}`, total_cost_usd: 0 });
+      this.emit('exit', 1);
+      return;
+    }
 
     let stdout = '';
     this.proc.stdout!.on('data', (chunk: Buffer) => {
       stdout += chunk.toString();
+    });
+
+    this.proc.on('error', (err) => {
+      console.error(`[GeminiEngine] process error: ${err.message}`);
+      this.emit('result', { type: 'result', result: `[GeminiEngine] process error: ${err.message}`, total_cost_usd: 0 });
+      this.emit('exit', 1);
     });
 
     this.proc.on('exit', (code) => {

--- a/src/utils/haiku.ts
+++ b/src/utils/haiku.ts
@@ -1,5 +1,7 @@
 import { spawn } from 'node:child_process';
 
+const MAX_STDOUT_SIZE = 5 * 1024 * 1024; // 5MB limit
+
 /**
  * Run a prompt through claude CLI with haiku model (single turn).
  * Shared utility — used by inbox-compactor, memory-consolidator, improvement-scanner.
@@ -17,9 +19,16 @@ export function runHaiku(prompt: string): Promise<string> {
 
     let stdout = '';
     let stderr = '';
+    let truncated = false;
 
     child.stdout.on('data', (chunk: Buffer) => {
+      if (truncated) return;
       stdout += chunk.toString();
+      if (stdout.length > MAX_STDOUT_SIZE) {
+        truncated = true;
+        console.warn(`[haiku] stdout exceeded ${MAX_STDOUT_SIZE} bytes, killing process`);
+        child.kill('SIGTERM');
+      }
     });
 
     child.stderr.on('data', (chunk: Buffer) => {
@@ -28,8 +37,8 @@ export function runHaiku(prompt: string): Promise<string> {
 
     child.on('error', (err) => reject(err));
     child.on('close', (code) => {
-      if (code === 0) {
-        resolve(stdout.trim());
+      if (code === 0 || truncated) {
+        resolve(stdout.trim().slice(0, MAX_STDOUT_SIZE));
       } else {
         reject(new Error(`claude exited with code ${code}: ${stderr.slice(0, 500)}`));
       }


### PR DESCRIPTION
## Summary
- hook-receiver: 1MB 요청 크기 제한 추가 (413 Payload Too Large 반환)
- haiku.ts: stdout 5MB 상한 + 초과 시 SIGTERM으로 프로세스 종료
- gemini-engine: spawn 에러 catch + process error 이벤트 핸들링으로 무한 대기 방지

## Test plan
- [ ] TypeScript 빌드 에러 0건 확인
- [ ] hook-receiver가 1MB 초과 요청 시 413 반환하는지 확인
- [ ] haiku 유틸리티가 대량 출력 시 정상 종료하는지 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)