### PR TITLE
fix. 엔진 에러 핸들링 및 리더 invoke 레이스 컨디션 방어

### DIFF
--- a/src/bot/inbox-compactor.ts
+++ b/src/bot/inbox-compactor.ts
@@ -572,6 +572,10 @@ export function startInboxCompactor(
     };
     addMessage(channelId, systemMsg);
     await sendAsTeam(channelId, leaderTeam, `📋 ${systemMsg.content}`).catch(err => console.warn('[inbox-compactor] sendAsTeam failed:', err instanceof Error ? err.message : err));
+    if (isOccupied(leaderTeam.id)) {
+      console.log('[inbox-compactor] Leader became busy before invoke, skipping');
+      return;
+    }
     triggerInvocation(leaderTeam, systemMsg, channelId, config, env, newChain());
   };
 

--- a/src/orchestrator/claude-engine.ts
+++ b/src/orchestrator/claude-engine.ts
@@ -68,6 +68,16 @@ export class ClaudeEngine extends BaseEngine {
       console.error(`[claude:${this.opts.teamId}] stderr: ${line.slice(0, 300)}`);
     });
 
+    this.proc.on('error', (err) => {
+      console.error(`[claude:${this.opts.teamId}] spawn error: ${err.message}`);
+      if (!procExited) {
+        exitCode = 1;
+        procExited = true;
+        rlClosed = true;
+        maybeEmitExit();
+      }
+    });
+
     this.proc.on('exit', (code) => {
       console.log(`[claude:${this.opts.teamId}] exited with code ${code}`);
       exitCode = code;

--- a/src/orchestrator/gemini-engine.ts
+++ b/src/orchestrator/gemini-engine.ts
@@ -14,9 +14,23 @@ export class GeminiEngine extends BaseEngine {
       stdio: ['ignore', 'pipe', 'pipe'],
     });
 
+    const MAX_STDOUT = 5 * 1024 * 1024; // 5MB
     let stdout = '';
+    let stdoutTruncated = false;
     this.proc.stdout!.on('data', (chunk: Buffer) => {
+      if (stdoutTruncated) return;
       stdout += chunk.toString();
+      if (stdout.length > MAX_STDOUT) {
+        stdoutTruncated = true;
+        stdout = stdout.slice(0, MAX_STDOUT);
+        console.warn(`[gemini:${this.opts.teamId}] stdout truncated at ${MAX_STDOUT} bytes`);
+        this.proc?.kill('SIGTERM');
+      }
+    });
+
+    this.proc.on('error', (err) => {
+      console.error(`[gemini:${this.opts.teamId}] spawn error: ${err.message}`);
+      this.emit('exit', 1);
     });
 
     this.proc.on('exit', (code) => {


### PR DESCRIPTION
## Summary
- ClaudeEngine: spawn error 핸들러 추가 (claude CLI 미설치/실행 실패 시 무한 대기 방지)
- GeminiEngine: spawn error 핸들러 + stdout 5MB 제한 (OOM 방지)
- immediateLeaderInvoke: invoke 직전 isOccupied 재검사 (이중 호출 방지)

## Test plan
- [ ] TypeScript 빌드 통과 확인
- [ ] claude/gemini CLI 미설치 환경에서 spawn error 정상 처리 확인
- [ ] 리더 동시 invoke 시 중복 방지 동작 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)