### PR TITLE
fix. HIGH 2건 + MEDIUM 6건 + LOW 1건 severity 이슈 수정

### DIFF
--- a/src/bot/client.ts
+++ b/src/bot/client.ts
@@ -298,13 +298,16 @@ export async function createBots(config: TeamsConfig, env: EnvConfig): Promise<v
   const MAX_TRACKED_MSGS = 500;
   const MSG_EXPIRY_MS = 5 * 60_000; // 5분 경과 메시지 자동 만료
 
-  function trimProcessedMsgs() {
-    // 먼저 오래된 항목 시간 기반 제거
+  /** Lightweight: only evict when size exceeds MAX — called on every message add. */
+  function evictOldestIfNeeded() {
+    if (processedMsgIds.size <= MAX_TRACKED_MSGS) return;
+    // 먼저 expired 항목 제거 시도 (size 이하로 줄어들면 조기 종료)
     const cutoff = Date.now() - MSG_EXPIRY_MS;
     for (const [id, ts] of processedMsgIds) {
+      if (processedMsgIds.size <= MAX_TRACKED_MSGS) break;
       if (ts < cutoff) processedMsgIds.delete(id);
     }
-    // 그래도 초과하면 FIFO 강제 제거 (Map 삽입 순서 이용)
+    // 여전히 초과면 FIFO 강제 제거 (Map 삽입 순서 이용)
     if (processedMsgIds.size <= MAX_TRACKED_MSGS) return;
     const overflow = processedMsgIds.size - MAX_TRACKED_MSGS;
     let removed = 0;
@@ -315,9 +318,17 @@ export async function createBots(config: TeamsConfig, env: EnvConfig): Promise<v
     }
   }
 
-  // 주기적 정리: 2분마다 만료 항목 제거
+  /** Full sweep: remove all expired entries — called periodically by setInterval. */
+  function cleanupExpiredEntries() {
+    const cutoff = Date.now() - MSG_EXPIRY_MS;
+    for (const [id, ts] of processedMsgIds) {
+      if (ts < cutoff) processedMsgIds.delete(id);
+    }
+  }
+
+  // 주기적 정리: 2분마다 만료 항목 전체 제거
   // Runs for entire process lifetime — no cleanup needed
-  setInterval(() => trimProcessedMsgs(), 2 * 60_000);
+  setInterval(() => cleanupExpiredEntries(), 2 * 60_000);
 
   // Forward hook events as team progress in Discord
   hookEvents.on('any', async (event) => {
@@ -498,7 +509,7 @@ export async function createBots(config: TeamsConfig, env: EnvConfig): Promise<v
         };
         if (!processedMsgIds.has(msg.id)) {
           processedMsgIds.set(msg.id, Date.now());
-          trimProcessedMsgs();
+          evictOldestIfNeeded();
           addMessage(msg.channelId, humanMsg);
           appendHrActivityLog(config.workspacePath, {
             ts: Date.now(),
@@ -536,7 +547,7 @@ export async function createBots(config: TeamsConfig, env: EnvConfig): Promise<v
         };
         if (!processedMsgIds.has(msg.id)) {
           processedMsgIds.set(msg.id, Date.now());
-          trimProcessedMsgs();
+          evictOldestIfNeeded();
           addMessage(msg.channelId, humanMsg);
           appendHrActivityLog(config.workspacePath, {
             ts: Date.now(),

--- a/src/bot/episode-writer.ts
+++ b/src/bot/episode-writer.ts
@@ -111,8 +111,12 @@ export function loadRecentEpisodes(
     const totalCorrupted = lines.filter(l => { try { const e = JSON.parse(l); return typeof e.ts !== 'number' || isNaN(e.ts); } catch { return true; } }).length;
     if (totalCorrupted > 0 && totalCorrupted / lines.length >= 0.3) {
       const validLines = lines.filter(l => { try { const e = JSON.parse(l); return typeof e.ts === 'number' && !isNaN(e.ts); } catch { return false; } });
-      atomicWriteSync(filePath, validLines.join('\n') + '\n');
-      console.log(`[episode] ${teamId}: Self-healing — ${totalCorrupted}건 손상 라인 제거, ${validLines.length}건 유지`);
+      try {
+        atomicWriteSync(filePath, validLines.join('\n') + '\n');
+        console.log(`[episode] ${teamId}: Self-healing — ${totalCorrupted}건 손상 라인 제거, ${validLines.length}건 유지`);
+      } catch (healErr) {
+        console.error(`[episode] ${teamId}: Self-healing write failed: ${healErr instanceof Error ? healErr.message : healErr}`);
+      }
     }
   }
 

--- a/src/bot/improvement-scanner.ts
+++ b/src/bot/improvement-scanner.ts
@@ -130,6 +130,9 @@ async function scanRepoFiles(repoPath: string): Promise<FileEntry[]> {
         commitCount = reduced;
         continue;
       }
+      if (result.truncated) {
+        console.warn(`[improvement-scanner] Output still truncated at MIN_COMMITS(${MIN_COMMITS}), using partial result`);
+      }
       output = result.output;
       break;
     } catch {
@@ -215,7 +218,7 @@ function buildScanPrompt(
     const repoIssues = existingIssues.filter(i => i.repo === repoName);
     if (repoIssues.length > 0) {
       const issueList = repoIssues
-        .map(i => `- [${i.severity}] ${i.file}: ${i.type} — ${i.description.slice(0, 100)}`)
+        .map(i => `- [${i.severity}] ${JSON.stringify(i.file).slice(1, -1)}: ${i.type} — ${i.description.slice(0, 100)}`)
         .join('\n');
       existingIssuesSection = `
 

--- a/src/bot/inbox-compactor.ts
+++ b/src/bot/inbox-compactor.ts
@@ -171,10 +171,12 @@ async function leaderHeartbeat(
         improvementReport = lines.join('\n');
       }
     } catch (err: unknown) {
-      // ENOENT is expected — improvement.json may not exist yet
-      if (err instanceof Error && 'code' in err && (err as NodeJS.ErrnoException).code === 'ENOENT') {
-        // silent: file does not exist yet, normal scenario
-      } else {
+      // ENOENT / EMPTY is expected — improvement.json may not exist yet or be empty
+      const isExpected = err instanceof Error && (
+        (err as NodeJS.ErrnoException).code === 'ENOENT' ||
+        (err as NodeJS.ErrnoException).code === 'EMPTY'
+      );
+      if (!isExpected) {
         console.warn(`[heartbeat] Failed to parse improvement.json: ${err}`);
       }
     }
@@ -275,7 +277,12 @@ async function followUpLoop(
       const nudgeLeader = Object.values(config.teams).find(t => t.isLeader);
       addMessage(record.channelId, nudgeMsg);
       if (nudgeLeader) await sendAsTeam(record.channelId, nudgeLeader, `📋 ${nudgeMsg.content}`).catch(err => console.warn('[inbox-compactor] sendAsTeam failed:', err instanceof Error ? err.message : err));
-      triggerInvocation(team, nudgeMsg, record.channelId, config, env, newChain());
+      // sendAsTeam await 후 재확인 — 비동기 간격 동안 상태 변경 가능
+      if (isOccupied(team.id)) {
+        console.log(`[follow-up] ${team.name} became occupied during nudge, skipping invocation`);
+      } else {
+        triggerInvocation(team, nudgeMsg, record.channelId, config, env, newChain());
+      }
       nudgeCounts.set(record.id, currentNudges + 1);
       setFollowUpCooldown(team.id);
       break; // One nudge per cycle
@@ -296,7 +303,12 @@ async function followUpLoop(
         if (alertChannelId) {
           addMessage(alertChannelId, alertMsg);
           await sendAsTeam(alertChannelId, leader, `📋 ${alertMsg.content}`).catch(err => console.warn('[inbox-compactor] sendAsTeam failed:', err instanceof Error ? err.message : err));
-          triggerInvocation(leader, alertMsg, alertChannelId, config, env, newChain());
+          // sendAsTeam await 후 재확인 — 비동기 간격 동안 상태 변경 가능
+          if (isOccupied(leader.id)) {
+            console.log(`[follow-up] Leader became occupied during alert, skipping invocation`);
+          } else {
+            triggerInvocation(leader, alertMsg, alertChannelId, config, env, newChain());
+          }
         }
       }
       // Auto-resolve after leader alert to prevent repeated notifications

--- a/src/bot/memory-consolidator.ts
+++ b/src/bot/memory-consolidator.ts
@@ -105,10 +105,19 @@ async function consolidateTeam(teamId: string, teamName: string, config: TeamsCo
 
     fs.mkdirSync(memoryDir, { recursive: true });
 
-    if (result.longTerm) {
-      atomicWriteSync(longTermPath, result.longTerm);
+    try {
+      if (result.longTerm) {
+        atomicWriteSync(longTermPath, result.longTerm);
+      }
+    } catch (err) {
+      console.error(`[memory-consolidator] Failed to write long-term for ${teamName}: ${err instanceof Error ? err.message : err}`);
     }
-    atomicWriteSync(shortTermPath, result.shortTerm);
+
+    try {
+      atomicWriteSync(shortTermPath, result.shortTerm);
+    } catch (err) {
+      console.error(`[memory-consolidator] Failed to write short-term for ${teamName}: ${err instanceof Error ? err.message : err}`);
+    }
 
     const promoted = result.longTerm && result.longTerm !== longTerm;
     console.log(`[memory-consolidator] Consolidated ${teamName}: short-term ${shortTerm.length}→${result.shortTerm.length} chars${promoted ? ', promoted items to long-term' : ''}`);
@@ -152,6 +161,31 @@ async function compactEpisodes(teamId: string, teamName: string, config: TeamsCo
   // 손상된 라인이 있으면 요약 로그 출력
   if (malformedCount > 0) {
     console.warn(`[memory-consolidator] ${teamName}: ${malformedCount}건의 손상된 에피소드 라인 스킵됨 (전체 ${lines.length}건 중)`);
+    // Self-healing: 손상 비율 30% 이상이면 유효한 라인만 유지
+    if (malformedCount / lines.length >= 0.3) {
+      const validLines = lines.filter(l => { try { JSON.parse(l); return true; } catch { return false; } });
+      try {
+        atomicWriteSync(filePath, validLines.join('\n') + '\n');
+        console.log(`[memory-consolidator] ${teamName}: Self-healing — ${malformedCount}건 손상 라인 제거, ${validLines.length}건 유지`);
+      } catch (err) {
+        console.error(`[memory-consolidator] ${teamName}: Self-healing write failed: ${err instanceof Error ? err.message : err}`);
+      }
+      // 유효한 라인만으로 재분류
+      old.length = 0;
+      recent.length = 0;
+      for (const line of validLines) {
+        try {
+          const ep: Episode = JSON.parse(line);
+          if (now - ep.ts > EPISODE_AGE_THRESHOLD_MS) {
+            old.push(ep);
+          } else {
+            recent.push(line);
+          }
+        } catch {
+          // already filtered
+        }
+      }
+    }
   }
 
   if (old.length < 2) return; // not enough old episodes to compact

--- a/src/orchestrator/claude-engine.ts
+++ b/src/orchestrator/claude-engine.ts
@@ -38,9 +38,12 @@ export class ClaudeEngine extends BaseEngine {
     let exitCode: number | null = null;
     let rlClosed = false;
     let procExited = false;
+    let exitEmitted = false;
 
     const maybeEmitExit = () => {
+      if (exitEmitted) return;
       if (rlClosed && procExited) {
+        exitEmitted = true;
         if (this.mcpConfigPath) cleanupMcpConfig(this.opts.teamId, this.opts.cwd);
         this.emit('exit', exitCode);
       }


### PR DESCRIPTION
## Summary
- **HIGH 2건**: client.ts processedMsgIds 만료 정리 효율화, inbox-compactor.ts race condition 방지
- **MEDIUM 6건**: memory-consolidator.ts 에러 처리 + 자가 치유, claude-engine.ts 중복 emit 방지, improvement-scanner.ts 보안 + truncation 처리, episode-writer.ts 에러 처리
- **LOW 1건**: inbox-compactor.ts ENOENT 에러 가독성 개선

## Changes (6 files, +86/-19)

### HIGH severity
| 파일 | 이슈 | 수정 내용 |
|-----|------|---------|
| `client.ts` | processedMsgIds 메모리 낭비 | `trimProcessedMsgs()` → `evictOldestIfNeeded()` + `cleanupExpiredEntries()` 분리. 매 메시지 시 O(1) early return, 전체 순회는 주기적 타이머에서만 |
| `inbox-compactor.ts` | followUpLoop race condition | `sendAsTeam` await 후 `isOccupied` 재확인 (nudge/alert 두 곳) |

### MEDIUM severity
| 파일 | 이슈 | 수정 내용 |
|-----|------|---------|
| `memory-consolidator.ts` | atomicWriteSync silent fail | longTerm/shortTerm 독립 try-catch로 분리 |
| `memory-consolidator.ts` | 손상 라인 누적 | 30% 이상 손상 시 self-healing + 재분류 |
| `claude-engine.ts` | exit 이벤트 중복 emit | `exitEmitted` 플래그 추가 |
| `improvement-scanner.ts` | 프롬프트 인젝션 | existingIssuesSection 파일 경로 `JSON.stringify` sanitize |
| `improvement-scanner.ts` | truncation 구분 불가 | MIN_COMMITS truncation 시 warn 로그 + 부분 결과 사용 |
| `episode-writer.ts` | self-healing 에러 전파 | `atomicWriteSync` try-catch 추가 |

### LOW severity
| 파일 | 이슈 | 수정 내용 |
|-----|------|---------|
| `inbox-compactor.ts` | ENOENT 가독성 | `isExpected` 패턴으로 통합 |

## Test plan
- [x] TypeScript 빌드 (`tsc --noEmit`) 통과
- [ ] 봇 재시작 후 정상 동작 확인
- [ ] improvement-scanner 스캔 주기에서 에러 없는지 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)