### PR TITLE
fix. summarizeInbox 멀티라인 메시지 파싱 실패 수정

### DIFF
--- a/src/bot/client.ts
+++ b/src/bot/client.ts
@@ -91,7 +91,9 @@ export function appendToInbox(teamId: string, from: string, content: string, wor
           fs.mkdirSync(dir, { recursive: true });
           const file = path.resolve(dir, `${teamId}.md`);
           const ts = new Date().toISOString().slice(0, 16).replace('T', ' ');
-          await fs.promises.appendFile(file, `[${ts} #ch:${channelId}] ${from}: ${content}\n`);
+          // Flatten multi-line content into single line to prevent summarizeInbox parse failures
+          const flat = content.replace(/\n+/g, ' ').replace(/\s{2,}/g, ' ');
+          await fs.promises.appendFile(file, `[${ts} #ch:${channelId}] ${from}: ${flat}\n`);
           if (settled) return;
           settled = true;
           clearTimeout(timeout);

--- a/src/orchestrator/prompt-builder.ts
+++ b/src/orchestrator/prompt-builder.ts
@@ -49,11 +49,26 @@ function readCached(filePath: string): string {
 function summarizeInbox(raw: string, teamId: string): string {
   if (!raw) return '';
 
-  const lines = raw.split('\n').filter(l => l.trim());
+  const lines = raw.split('\n');
+
+  // Merge continuation lines (lines not starting with '[') into the preceding entry.
+  // Multi-line Discord messages written before the appendToInbox flatten fix
+  // would produce orphan lines that fail the per-line regex.
+  const merged: string[] = [];
+  for (const line of lines) {
+    if (!line.trim()) continue;
+    if (/^\[/.test(line)) {
+      merged.push(line);
+    } else if (merged.length > 0) {
+      merged[merged.length - 1] += ' ' + line.trim();
+    } else {
+      merged.push(line);
+    }
+  }
 
   // Parse into entries (each line is "[timestamp] sender: content")
   const failedLines: string[] = [];
-  const entries = lines.map(line => {
+  const entries = merged.map(line => {
     const match = line.match(/^\[([^\]]+)\]\s+([^:]+):\s*([\s\S]*)$/);
     if (!match) {
       failedLines.push(line);
@@ -70,11 +85,11 @@ function summarizeInbox(raw: string, teamId: string): string {
     const sample = failedLines.length <= 3
       ? failedLines.map(l => l.slice(0, 80)).join('; ')
       : failedLines.slice(0, 3).map(l => l.slice(0, 80)).join('; ') + '...';
-    const failRatio = failedLines.length / lines.length;
+    const failRatio = failedLines.length / merged.length;
     if (failRatio > 0.5) {
-      console.error(`[summarizeInbox] ${teamId}: ${failedLines.length}/${lines.length}건 파싱 실패 (${(failRatio * 100).toFixed(0)}% — 과반 이상) — ${sample}`);
+      console.error(`[summarizeInbox] ${teamId}: ${failedLines.length}/${merged.length}건 파싱 실패 (${(failRatio * 100).toFixed(0)}% — 과반 이상) — ${sample}`);
     } else {
-      console.warn(`[summarizeInbox] ${teamId}: ${failedLines.length}/${lines.length}건 파싱 실패 — ${sample}`);
+      console.warn(`[summarizeInbox] ${teamId}: ${failedLines.length}/${merged.length}건 파싱 실패 — ${sample}`);
     }
   }
 


### PR DESCRIPTION
## 원인
`appendToInbox`가 Discord 메시지를 그대로 파일에 기록하는데, 메시지에 개행(`\n`)이 포함되면 inbox 파일에 멀티라인 엔트리가 생긴다. `summarizeInbox`는 `\n`으로 split 후 각 줄을 `[timestamp] sender: content` 패턴으로 파싱하므로, 개행으로 나뉜 2번째 줄부터 전부 파싱 실패 → 대장코코가 팀원 보고를 받지 못하는 구조적 문제 발생.

## 수정 내용

| 파일 | 변경 |
|------|------|
| `src/bot/client.ts` | `appendToInbox`: content 내 개행을 공백으로 치환하여 항상 단일 라인 기록 |
| `src/orchestrator/prompt-builder.ts` | `summarizeInbox`: `[` 로 시작하지 않는 줄을 이전 엔트리에 병합하는 방어 파싱 추가, failRatio 기준을 병합 후 라인 수로 변경 |

## 테스트
- `npm run build` 통과

🤖 Generated with [Claude Code](https://claude.com/claude-code)