### PR TITLE
fix. BE코코→배포 중립 이름 마이그레이션

### DIFF
--- a/src/orchestrator/prompt-builder.ts
+++ b/src/orchestrator/prompt-builder.ts
@@ -202,8 +202,8 @@ Use these sections to organize:
 
 ### 팀 역량
 예시:
-- BE코코: API 설계, DB 마이그레이션, 성능 최적화
-- FE코코: React, 배포 파이프라인, UI/UX
+- Backend팀: API 설계, DB 마이그레이션, 성능 최적화
+- Frontend팀: React, 배포 파이프라인, UI/UX
 
 ${longTerm ? `\n${longTerm}\n` : '\n(empty)\n'}
 ## Short-term Memory
@@ -214,13 +214,13 @@ Use these sections to organize:
 (현재 태스크, 담당자, 블로커 — 반드시 #ch:숫자ID 포함)
 예시:
 - FE 배포 스크립트 작성 중 #ch:${chId}
-- BE코코에게 API 연동 위임, 결과 대기 #ch:${chId}
+- 팀원A에게 API 연동 위임, 결과 대기 #ch:${chId}
 
 ### 대기 항목
 (미완료 작업 — 반드시 #ch:숫자ID 포함. 태그: [BLOCKED], [SCHEDULED:YYYY-MM-DD], [READY])
 예시:
 - DB 마이그레이션 실행 #ch:1234567890123456
-- Redis 설정 [BLOCKED] — BE코코 완료 대기 #ch:1234567890123456
+- Redis 설정 [BLOCKED] — 팀원A 완료 대기 #ch:1234567890123456
 - 주간보고 작성 [SCHEDULED:2026-02-17] #ch:9876543210123456
 
 ### 캐시된 외부 데이터
@@ -245,7 +245,7 @@ Levels:
 - \`propose\` — 새 기능, 아키텍처 변경, 새 도구 도입. 회장님 승인 대기.
 - \`escalate\` — 보안, 장애, 긴급. 즉시 회장님 태그.
 
-예: \`[decision:autonomous reason="중복 코드 발견" action="BE코코에게 리팩토링 지시"]\`
+예: \`[decision:autonomous reason="중복 코드 발견" action="Backend팀에게 리팩토링 지시"]\`
 예: \`[decision:propose reason="새 인증 시스템 필요" action="회장님 승인 대기"]\`
 `;
 


### PR DESCRIPTION
## Summary
- `prompt-builder.ts`에서 `BE코코`, `FE코코` 하드코딩 참조를 배포 중립적 이름(`Backend팀`, `Frontend팀`, `팀원A`)으로 변경
- 삭제된 `BE코코` 팀 참조로 인한 혼동 방지

## 근본 원인 분석
`be.md` ENOENT 및 `sendAsTeam No client for team BE코코 (be)` 에러의 실제 원인:
- `mococo-corps/teams.json`은 이미 `be` → `stack`으로 마이그레이션 완료
- `prompts/stack.md` 정상 존재
- **실행 중인 봇이 업데이트 이전 설정으로 기동된 상태** → 재시작 필요

코드 내 `BE코코` 참조는 기능 코드가 아닌 프롬프트 예시 텍스트에만 존재하여 크래시 원인은 아님. 정리 차원에서 수정.

## 필요 후속 조치
- 봇 재시작 (`mococo restart`) → ENOENT 에러 해소

🤖 Generated with [Claude Code](https://claude.com/claude-code)