### PR TITLE
feat. 재시작 시 GitHub PR 실제 상태 조회 후 메모리 업데이트

### DIFF
--- a/src/bot/client.ts
+++ b/src/bot/client.ts
@@ -17,6 +17,7 @@ import { startInboxCompactor } from './inbox-compactor.js';
 import { startMemoryConsolidator, checkSizeBasedConsolidation } from './memory-consolidator.js';
 import { startImprovementScanner } from './improvement-scanner.js';
 import { writeEpisode } from './episode-writer.js';
+import { verifyPRStatuses } from '../utils/github-status.js';
 import type { TeamsConfig, TeamConfig, EnvConfig, ConversationMessage, ChainContext } from '../types.js';
 
 // ---------------------------------------------------------------------------
@@ -551,14 +552,18 @@ export async function createBots(config: TeamsConfig, env: EnvConfig): Promise<v
     handleTeamInvocation(team, triggerMsg, channelId, config, env, newChain());
   }, env.workChannelId || env.memberTrackingChannelId);
 
-  // Leader startup message — notify channel and invoke leader for memory cleanup
+  // Leader startup message — verify actual state, then invoke leader for memory update
   const startupLeader = Object.values(config.teams).find(t => t.isLeader);
   const startupChannelId = env.workChannelId || env.memberTrackingChannelId;
   if (startupLeader && startupChannelId) {
     // Delay to ensure all bots are ready and background tasks initialized
     setTimeout(async () => {
       try {
-        // Read leader's short-term memory once for pending tasks & in-progress
+        // 1. Check actual GitHub PR statuses referenced in ALL team memories
+        const teamIds = Object.keys(config.teams);
+        const { report: prStatusReport } = await verifyPRStatuses(config.workspacePath, teamIds);
+
+        // 2. Read leader's short-term memory for pending tasks & in-progress
         const shortTermPath = path.resolve(config.workspacePath, '.mococo/memory', startupLeader.id, 'short-term.md');
         let pendingSummary = '';
         let inProgressSummary = '';
@@ -569,7 +574,7 @@ export async function createBots(config: TeamsConfig, env: EnvConfig): Promise<v
           if (pendingMatch) {
             const lines = pendingMatch[1].split('\n').filter(l => /^\s*-\s+.+/.test(l));
             if (lines.length > 0) {
-              pendingSummary = `\n\n**대기 항목 (${lines.length}건):**\n${lines.join('\n')}`;
+              pendingSummary = `\n\n**대기 항목 — 메모리 기준 (${lines.length}건):**\n${lines.join('\n')}`;
             }
           }
 
@@ -577,18 +582,25 @@ export async function createBots(config: TeamsConfig, env: EnvConfig): Promise<v
           if (progressMatch) {
             const lines = progressMatch[1].split('\n').filter(l => /^\s*-\s+.+/.test(l));
             if (lines.length > 0) {
-              inProgressSummary = `\n\n**진행중 작업 (${lines.length}건):**\n${lines.join('\n')}`;
+              inProgressSummary = `\n\n**진행중 작업 — 메모리 기준 (${lines.length}건):**\n${lines.join('\n')}`;
             }
           }
         } catch { /* no short-term memory yet */ }
 
         const now = new Date().toLocaleString('ko-KR', { timeZone: 'Asia/Seoul', hour: '2-digit', minute: '2-digit' });
-        const startupContent = `🔄 **시스템 재시작 완료** (${now} KST)${inProgressSummary}${pendingSummary}\n\n메모리 상태를 정리하겠습니다.`;
+        const startupContent = `🔄 **시스템 재시작 완료** (${now} KST)${prStatusReport}${inProgressSummary}${pendingSummary}\n\n실제 상태 기준으로 메모리를 정리하겠습니다.`;
+
+        // 3. Build system message with actual verified states
+        let systemContent = '[시스템 재시작] 봇이 재시작되었습니다.';
+        if (prStatusReport) {
+          systemContent += `\n\n아래는 GitHub API로 조회한 PR 실제 상태입니다. 메모리에 기록된 PR 상태와 비교하여, 실제 상태와 다른 항목은 메모리를 업데이트하세요.${prStatusReport}`;
+        }
+        systemContent += '\n\n메모리 상태를 실제 상태 기준으로 점검·업데이트한 후, 채널에 상태 정리 메시지를 출력하세요.';
 
         const systemMsg: ConversationMessage = {
           teamId: 'system',
           teamName: 'System',
-          content: `[시스템 재시작] 봇이 재시작되었습니다. 메모리 상태를 점검하고, 대기중 작업을 확인한 후, 채널에 상태 정리 메시지를 출력하세요.`,
+          content: systemContent,
           timestamp: new Date(),
           mentions: [startupLeader.id],
         };
@@ -598,7 +610,7 @@ export async function createBots(config: TeamsConfig, env: EnvConfig): Promise<v
         );
         addMessage(startupChannelId, systemMsg);
         handleTeamInvocation(startupLeader, systemMsg, startupChannelId, config, env, newChain());
-        console.log('[startup] Leader startup message sent and invocation triggered');
+        console.log('[startup] Leader startup message sent with verified PR statuses');
       } catch (err) {
         console.error(`[startup] Failed to send startup message: ${err}`);
       }

--- a/src/utils/github-status.ts
+++ b/src/utils/github-status.ts
@@ -1,0 +1,204 @@
+import fs from 'node:fs';
+import path from 'node:path';
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+export interface PRInfo {
+  owner: string;
+  repo: string;
+  number: number;
+}
+
+export interface PRStatus extends PRInfo {
+  state: 'open' | 'closed';
+  merged: boolean;
+  title: string;
+}
+
+// ---------------------------------------------------------------------------
+// Repo discovery — read git remotes from repos/ directory
+// ---------------------------------------------------------------------------
+
+export function discoverRepos(workspacePath: string): Map<string, { owner: string; repo: string }> {
+  const reposDir = path.resolve(workspacePath, 'repos');
+  const result = new Map<string, { owner: string; repo: string }>();
+
+  try {
+    const entries = fs.readdirSync(reposDir, { withFileTypes: true });
+    for (const entry of entries) {
+      if (!entry.isDirectory()) continue;
+      const gitConfigPath = path.join(reposDir, entry.name, '.git', 'config');
+      try {
+        const gitConfig = fs.readFileSync(gitConfigPath, 'utf-8');
+        // Match both HTTPS and SSH remotes
+        const urlMatch = gitConfig.match(
+          /url\s*=\s*(?:https:\/\/github\.com\/|git@github\.com:)([^/\s]+)\/([^/\s.]+)/,
+        );
+        if (urlMatch) {
+          result.set(entry.name, { owner: urlMatch[1], repo: urlMatch[2] });
+        }
+      } catch { /* no git config */ }
+    }
+  } catch { /* no repos dir */ }
+
+  return result;
+}
+
+// ---------------------------------------------------------------------------
+// PR reference extraction from memory text
+// ---------------------------------------------------------------------------
+
+export function extractPRs(
+  content: string,
+  repos: Map<string, { owner: string; repo: string }>,
+): PRInfo[] {
+  const prs: PRInfo[] = [];
+  const seen = new Set<string>();
+
+  // 1. Match full GitHub URLs: github.com/owner/repo/pull/N
+  const urlRegex = /github\.com\/([^/\s]+)\/([^/\s]+)\/pull\/(\d+)/g;
+  let match;
+  while ((match = urlRegex.exec(content)) !== null) {
+    const key = `${match[1]}/${match[2]}#${match[3]}`;
+    if (!seen.has(key)) {
+      seen.add(key);
+      prs.push({ owner: match[1], repo: match[2], number: parseInt(match[3]) });
+    }
+  }
+
+  // 2. Match bare PR #N — resolve against known repos
+  const bareRegex = /PR\s*#(\d+)/gi;
+  while ((match = bareRegex.exec(content)) !== null) {
+    const num = parseInt(match[1]);
+    // Skip if already found via URL
+    if (prs.some(p => p.number === num)) continue;
+    // Add for each known repo (API will confirm which one has it)
+    for (const [, info] of repos) {
+      const key = `${info.owner}/${info.repo}#${num}`;
+      if (!seen.has(key)) {
+        seen.add(key);
+        prs.push({ owner: info.owner, repo: info.repo, number: num });
+      }
+    }
+  }
+
+  return prs;
+}
+
+// ---------------------------------------------------------------------------
+// GitHub API — check actual PR statuses
+// ---------------------------------------------------------------------------
+
+export async function checkPRStatuses(prs: PRInfo[]): Promise<PRStatus[]> {
+  const token = process.env.GITHUB_TOKEN || process.env.GH_TOKEN;
+  if (!token) {
+    console.warn('[github-status] No GITHUB_TOKEN or GH_TOKEN — skipping PR status check');
+    return [];
+  }
+  if (prs.length === 0) return [];
+
+  const results: PRStatus[] = [];
+
+  for (const pr of prs) {
+    try {
+      const res = await fetch(
+        `https://api.github.com/repos/${pr.owner}/${pr.repo}/pulls/${pr.number}`,
+        {
+          headers: {
+            Authorization: `Bearer ${token}`,
+            Accept: 'application/vnd.github+json',
+            'X-GitHub-Api-Version': '2022-11-28',
+          },
+        },
+      );
+
+      if (res.status === 404) continue; // PR doesn't exist in this repo
+      if (!res.ok) {
+        console.warn(`[github-status] API error for ${pr.owner}/${pr.repo}#${pr.number}: ${res.status}`);
+        continue;
+      }
+
+      const data = (await res.json()) as { state: string; merged: boolean; title: string };
+      results.push({
+        owner: pr.owner,
+        repo: pr.repo,
+        number: pr.number,
+        state: data.state as 'open' | 'closed',
+        merged: data.merged ?? false,
+        title: data.title,
+      });
+    } catch (err) {
+      console.warn(`[github-status] Error checking ${pr.owner}/${pr.repo}#${pr.number}:`, err);
+    }
+  }
+
+  return results;
+}
+
+// ---------------------------------------------------------------------------
+// Format status report for system message
+// ---------------------------------------------------------------------------
+
+export function formatPRStatusReport(statuses: PRStatus[]): string {
+  if (statuses.length === 0) return '';
+
+  const lines = statuses.map(s => {
+    const stateText = s.merged
+      ? '✅ merged'
+      : s.state === 'closed'
+        ? '❌ closed'
+        : '🔵 open';
+    return `- ${s.owner}/${s.repo} PR #${s.number}: ${stateText} — ${s.title}`;
+  });
+
+  return `\n\n**GitHub PR 실제 상태 (API 조회 결과):**\n${lines.join('\n')}`;
+}
+
+// ---------------------------------------------------------------------------
+// High-level: check all PR statuses referenced in team memories
+// ---------------------------------------------------------------------------
+
+export async function verifyPRStatuses(workspacePath: string, teamIds: string[]): Promise<{
+  statuses: PRStatus[];
+  report: string;
+}> {
+  const repos = discoverRepos(workspacePath);
+  if (repos.size === 0) {
+    return { statuses: [], report: '' };
+  }
+
+  // Collect PR references from all team memories
+  const allPRs: PRInfo[] = [];
+  const seen = new Set<string>();
+
+  for (const teamId of teamIds) {
+    const shortTermPath = path.resolve(workspacePath, '.mococo/memory', teamId, 'short-term.md');
+    try {
+      const stm = fs.readFileSync(shortTermPath, 'utf-8');
+      for (const pr of extractPRs(stm, repos)) {
+        const key = `${pr.owner}/${pr.repo}#${pr.number}`;
+        if (!seen.has(key)) {
+          seen.add(key);
+          allPRs.push(pr);
+        }
+      }
+    } catch { /* no memory file */ }
+  }
+
+  if (allPRs.length === 0) {
+    return { statuses: [], report: '' };
+  }
+
+  console.log(`[github-status] Checking ${allPRs.length} PR(s) across ${repos.size} repo(s)...`);
+  const statuses = await checkPRStatuses(allPRs);
+  const report = formatPRStatusReport(statuses);
+
+  if (statuses.length > 0) {
+    console.log(`[github-status] Verified ${statuses.length} PR(s):`,
+      statuses.map(s => `${s.owner}/${s.repo}#${s.number}=${s.merged ? 'merged' : s.state}`).join(', '));
+  }
+
+  return { statuses, report };
+}


### PR DESCRIPTION
## Summary
- 재시작 시 메모리 기반 판단 → **GitHub API로 PR 실제 상태 조회** 방식으로 변경
- `src/utils/github-status.ts`: PR 참조 추출, GitHub API 상태 조회, 보고 포맷팅 유틸리티
- `src/bot/client.ts`: startup 로직에서 `verifyPRStatuses()` 호출 → 시스템 메시지에 실제 상태 포함

## 변경 사항
1. **`github-status.ts` (신규)**: 워크스페이스 repos/ 디렉토리에서 GitHub 레포 자동 감지, 팀 메모리에서 PR 참조 추출 (URL + bare `PR #N`), GitHub REST API로 실제 상태 조회
2. **`client.ts` (수정)**: startup 시 전 팀 메모리에서 PR 참조 수집 → API 조회 → 리더에게 실제 상태 전달 → 리더가 메모리 업데이트

## 동작 흐름
```
재시작 → 5초 대기 → 전 팀 메모리에서 PR 참조 수집
→ GitHub API로 실제 상태 조회 (open/merged/closed)
→ 시스템 메시지에 조회 결과 포함
→ 리더가 실제 상태 기준으로 메모리 업데이트 + 채널 보고
```

## 환경 요구사항
- `GITHUB_TOKEN` 또는 `GH_TOKEN` 환경변수 필요 (없으면 조회 스킵, 기존 동작 유지)

## Test plan
- [ ] `GITHUB_TOKEN` 설정 후 재시작 시 PR 상태가 정확히 조회되는지 확인
- [ ] 토큰 없을 때 graceful fallback (기존 동작 유지) 확인
- [ ] 머지된 PR이 "대기 중"이 아닌 "merged"로 보고되는지 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)