### PR TITLE
fix. 코드 개선 4건 — silent catch, snowflake 검증, path traversal 방어, 정리 보장

### DIFF
--- a/src/bot/client.ts
+++ b/src/bot/client.ts
@@ -115,7 +115,13 @@ export function appendToInbox(teamId: string, from: string, content: string, wor
 
 export function clearInbox(teamId: string, workspacePath: string) {
   const file = path.resolve(workspacePath, '.mococo/inbox', `${teamId}.md`);
-  try { fs.unlinkSync(file); } catch {}
+  try {
+    fs.unlinkSync(file);
+  } catch (err: any) {
+    if (err?.code !== 'ENOENT') {
+      console.error(`[clearInbox] Failed to delete ${file}:`, err);
+    }
+  }
 }
 
 // ---------------------------------------------------------------------------
@@ -315,7 +321,13 @@ export async function createBots(config: TeamsConfig, env: EnvConfig): Promise<v
 
   // 주기적 정리: 2분마다 만료 항목 전체 제거
   // Runs for entire process lifetime — no cleanup needed
-  setInterval(() => cleanupExpiredEntries(), 2 * 60_000);
+  setInterval(() => {
+    try {
+      cleanupExpiredEntries();
+    } catch (err) {
+      console.error('[processedMsgIds] Periodic cleanup failed:', err);
+    }
+  }, 2 * 60_000);
 
   // Forward hook events as team progress in Discord
   hookEvents.on('any', async (event) => {
@@ -632,7 +644,11 @@ function resetTeamMemory(teamId: string, workspacePath: string): string[] {
         fs.unlinkSync(filePath);
         cleared.push(file);
       }
-    } catch {}
+    } catch (err: any) {
+      if (err?.code !== 'ENOENT') {
+        console.error(`[resetTeamMemory] Failed to delete ${filePath}:`, err);
+      }
+    }
   }
 
   return cleared;

--- a/src/bot/discord-commands.ts
+++ b/src/bot/discord-commands.ts
@@ -309,6 +309,17 @@ async function executeCommand(cmd: ParsedCommand, ctx: CommandContext): Promise<
 
 // --- Resolve helpers ---
 
+/** Validate Discord snowflake format (17-20 digit numeric string) */
+function isValidSnowflake(id: string): boolean {
+  return /^\d{17,20}$/.test(id);
+}
+
+/** Strip Discord mention syntax and validate as snowflake */
+function parseUserId(raw: string): string | null {
+  const cleaned = raw.replace(/[<@!>]/g, '');
+  return isValidSnowflake(cleaned) ? cleaned : null;
+}
+
 function resolveChannel(name: string, ctx: CommandContext): TextChannel | undefined {
   // Check registry first
   const id = ctx.registry.getChannel(name);
@@ -652,7 +663,12 @@ async function handleSetPermission(params: Record<string, string>, ctx: CommandC
       return;
     }
   } else if (params.user) {
-    targetId = params.user.replace(/[<@!>]/g, '');
+    const parsed = parseUserId(params.user);
+    if (!parsed) {
+      console.warn(`[discord-cmd] Invalid user ID format: "${params.user}"`);
+      return;
+    }
+    targetId = parsed;
   }
   if (!targetId) return;
 
@@ -683,7 +699,12 @@ async function handleRemovePermission(params: Record<string, string>, ctx: Comma
     const role = resolveRole(params.role, ctx);
     targetId = role?.id;
   } else if (params.user) {
-    targetId = params.user.replace(/[<@!>]/g, '');
+    const parsed = parseUserId(params.user);
+    if (!parsed) {
+      console.warn(`[discord-cmd] Invalid user ID format: "${params.user}"`);
+      return;
+    }
+    targetId = parsed;
   }
   if (!targetId) return;
 
@@ -732,7 +753,11 @@ async function handleAssignRole(params: Record<string, string>, ctx: CommandCont
   }
 
   // Accept raw ID or <@ID> mention format
-  const cleanId = userId.replace(/[<@!>]/g, '');
+  const cleanId = parseUserId(userId);
+  if (!cleanId) {
+    console.warn(`[discord-cmd] Invalid user ID format: "${userId}"`);
+    return;
+  }
   const member = await ctx.guild.members.fetch(cleanId).catch(() => null);
   if (!member) {
     console.warn(`[discord-cmd] Member "${userId}" not found`);
@@ -754,7 +779,11 @@ async function handleRemoveRole(params: Record<string, string>, ctx: CommandCont
     return;
   }
 
-  const cleanId = userId.replace(/[<@!>]/g, '');
+  const cleanId = parseUserId(userId);
+  if (!cleanId) {
+    console.warn(`[discord-cmd] Invalid user ID format: "${userId}"`);
+    return;
+  }
   const member = await ctx.guild.members.fetch(cleanId).catch(() => null);
   if (!member) {
     console.warn(`[discord-cmd] Member "${userId}" not found`);
@@ -868,6 +897,10 @@ async function handleEditPersona(params: Record<string, string>, ctx: CommandCon
   if (!content) return;
 
   const promptPath = path.resolve(ctx.config.workspacePath, ctx.team.prompt);
+  if (!promptPath.startsWith(ctx.config.workspacePath + path.sep)) {
+    console.error(`[discord-cmd] Path traversal detected in persona path: "${ctx.team.prompt}"`);
+    return;
+  }
   fs.writeFileSync(promptPath, content);
   console.log(`[discord-cmd] Updated persona for ${ctx.team.name} at ${ctx.team.prompt}`);
   await ctx.sendAsTeam(ctx.channelId, ctx.team, `Persona updated.`);

--- a/src/orchestrator/mcp-config.ts
+++ b/src/orchestrator/mcp-config.ts
@@ -20,7 +20,9 @@ export function cleanupMcpConfig(teamId: string, cwd: string): void {
   const filePath = path.resolve(cwd, '.mococo', 'mcp', `${teamId}.json`);
   try {
     fs.unlinkSync(filePath);
-  } catch {
-    // already removed — ignore
+  } catch (err: any) {
+    if (err?.code !== 'ENOENT') {
+      console.error(`[cleanupMcpConfig] Failed to delete ${filePath}:`, err);
+    }
   }
 }

--- a/src/orchestrator/prompt-builder.ts
+++ b/src/orchestrator/prompt-builder.ts
@@ -366,8 +366,12 @@ export async function buildTeamPrompt(
   const ws = config.workspacePath;
   const chId = invocation.channelId;
 
-  // 1. Load base resources
-  const template = fs.readFileSync(path.resolve(ws, team.prompt), 'utf-8');
+  // 1. Load base resources (with path traversal guard)
+  const templatePath = path.resolve(ws, team.prompt);
+  if (!templatePath.startsWith(ws + path.sep) && templatePath !== ws) {
+    throw new Error(`[prompt-builder] Path traversal detected: team.prompt "${team.prompt}" resolves outside workspace`);
+  }
+  const template = fs.readFileSync(templatePath, 'utf-8');
   const conversationText = formatConversation(invocation.conversation);
   const sharedRules = readCached(path.resolve(ws, 'prompts/shared-rules.md'));
   const memberList = readCached(path.resolve(ws, '.mococo/members.md'));


### PR DESCRIPTION
## Summary
- **silent catch 개선**: `clearInbox`, `cleanupMcpConfig`, `resetTeamMemory`에서 빈 catch 블록 → ENOENT 외 에러 로깅
- **Discord ID snowflake 검증**: `parseUserId()` 헬퍼 도입, 4곳의 user ID 처리에서 17-20자리 숫자 포맷 검증 후 API 호출
- **path traversal 방어**: `prompt-builder`, `handleEditPersona`에서 resolve된 경로가 workspace 밖인지 검증
- **processedMsgIds 정리 보장**: setInterval 콜백에 try-catch 추가로 정리 함수 실패 시에도 다음 주기 정상 동작

## Changes
| 파일 | 변경 |
|------|------|
| `src/bot/client.ts` | silent catch 3곳 + setInterval 에러 핸들링 |
| `src/bot/discord-commands.ts` | `parseUserId` 헬퍼 + 4곳 적용 + persona path 검증 |
| `src/orchestrator/mcp-config.ts` | silent catch 1곳 |
| `src/orchestrator/prompt-builder.ts` | template path traversal 검증 |

## Test plan
- [ ] 빌드 통과 확인 (tsc --noEmit)
- [ ] 봇 재시작 후 정상 동작 확인
- [ ] 잘못된 user ID로 role assign 시 경고 로그 출력 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)