### PR TITLE
fix. MEMORY/PERSONA 블럭 Discord 노출 방지 safety-net 추가

### DIFF
--- a/src/bot/client.ts
+++ b/src/bot/client.ts
@@ -238,6 +238,21 @@ function updateMemberTracking(
 
 const registry = new ResourceRegistry();
 
+// Safety-net: strip any internal command blocks that should never reach Discord
+const INTERNAL_BLOCK_PATTERNS = [
+  /(?:```\s*\n?)?(?:\[discord:edit-memory\]\s*\n)?-{3,}MEMORY-{3,}\s*\n[\s\S]*?\n-{3,}END-MEMORY-{3,}(?:\s*\n?```)?/g,
+  /(?:```\s*\n?)?(?:\[discord:edit-long-memory\]\s*\n)?-{3,}LONG-MEMORY-{3,}\s*\n[\s\S]*?\n-{3,}END-LONG-MEMORY-{3,}(?:\s*\n?```)?/g,
+  /(?:```\s*\n?)?(?:\[discord:edit-persona\]\s*\n)?-{3,}PERSONA-{3,}\s*\n[\s\S]*?\n-{3,}END-PERSONA-{3,}(?:\s*\n?```)?/g,
+];
+
+function sanitizeForDiscord(text: string): string {
+  let result = text;
+  for (const pattern of INTERNAL_BLOCK_PATTERNS) {
+    result = result.replace(pattern, '');
+  }
+  return result.replace(/\n{3,}/g, '\n\n').trim();
+}
+
 export async function sendAsTeam(channelId: string, team: TeamConfig, content: string): Promise<boolean> {
   const client = teamClients.get(team.id);
   if (!client) {
@@ -251,7 +266,10 @@ export async function sendAsTeam(channelId: string, team: TeamConfig, content: s
     return false;
   }
 
-  const chunks = splitMessage(content, 1900);
+  const sanitized = sanitizeForDiscord(content);
+  if (!sanitized) return true;
+
+  const chunks = splitMessage(sanitized, 1900);
   for (const chunk of chunks) {
     await channel.send(chunk);
   }


### PR DESCRIPTION
## Summary
- `sendAsTeam()` 함수에 `sanitizeForDiscord()` safety-net 추가
- `---MEMORY---`, `---LONG-MEMORY---`, `---PERSONA---` 블럭이 Discord 채팅에 노출되는 버그 수정
- 기존 `stripMemoryBlocks()`는 `handleTeamInvocation` 경로에서만 호출되어, 다른 전송 경로(hook events, error messages, inbox compactor)에서 블럭이 누출될 수 있었음
- 메시지 전송 최종 단계에서 필터링하여 모든 경로에서 안전하게 차단

## Test plan
- [ ] 봇 재시작 후 메모리 블럭이 포함된 응답 생성 → Discord에 블럭 미노출 확인
- [ ] 메모리 저장 기능 정상 동작 확인 (stripMemoryBlocks에서 처리)
- [ ] tsc --noEmit 빌드 통과 확인 ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)