### PR TITLE
fix. summarizeInbox 파싱 실패 근본 원인 수정

### DIFF
--- a/src/bot/client.ts
+++ b/src/bot/client.ts
@@ -92,7 +92,7 @@ export function appendToInbox(teamId: string, from: string, content: string, wor
           const file = path.resolve(dir, `${teamId}.md`);
           const ts = new Date().toISOString().slice(0, 16).replace('T', ' ');
           // Flatten multi-line content into single line to prevent summarizeInbox parse failures
-          const flat = content.replace(/\n+/g, ' ').replace(/\s{2,}/g, ' ');
+          const flat = content.replace(/[\r\n]+/g, ' ').replace(/\s{2,}/g, ' ');
           await fs.promises.appendFile(file, `[${ts} #ch:${channelId}] ${from}: ${flat}\n`);
           if (settled) return;
           settled = true;

--- a/src/orchestrator/prompt-builder.ts
+++ b/src/orchestrator/prompt-builder.ts
@@ -51,19 +51,19 @@ function summarizeInbox(raw: string, teamId: string): string {
 
   const lines = raw.split('\n');
 
-  // Merge continuation lines (lines not starting with '[') into the preceding entry.
-  // Multi-line Discord messages written before the appendToInbox flatten fix
-  // would produce orphan lines that fail the per-line regex.
+  // Merge continuation lines into the preceding entry.
+  // A new entry starts with a timestamp pattern like "[2026-02-19 02:40 #ch:..."
+  // Using specific pattern avoids false splits on markdown links like "[text](url)".
+  const ENTRY_START = /^\[\d{4}-\d{2}-\d{2} \d{2}:\d{2}/;
   const merged: string[] = [];
   for (const line of lines) {
     if (!line.trim()) continue;
-    if (/^\[/.test(line)) {
+    if (ENTRY_START.test(line)) {
       merged.push(line);
     } else if (merged.length > 0) {
       merged[merged.length - 1] += ' ' + line.trim();
-    } else {
-      merged.push(line);
     }
+    // Orphan lines before any entry are dropped (no valid timestamp prefix)
   }
 
   // Parse into entries (each line is "[timestamp] sender: content")


### PR DESCRIPTION
## 근본 원인

**dist가 PR #12 수정 사항 없이 빌드되어 실행 중이었음.**

실제 봇이 실행되는 `/Users/move/claude-mococo/dist/`를 확인한 결과:
- `dist/bot/client.js`: content flatten 로직 없음 (raw 멀티라인 그대로 저장)
- `dist/orchestrator/prompt-builder.js`: continuation line merge 로직 없음 (각 줄 독립 파싱)

→ 멀티라인 Discord 메시지가 inbox에 그대로 기록되고, 각 줄이 개별 파싱 대상이 되어 `[timestamp]` 패턴 불일치로 80~90% 실패

## 추가 개선 (이번 PR)

### 1. merge 패턴 정밀화 (`prompt-builder.ts`)
- Before: `^\[` — `[` 로 시작하는 모든 줄을 새 엔트리로 인식
- After: `^\[\d{4}-\d{2}-\d{2} \d{2}:\d{2}` — 실제 타임스탬프 패턴만 인식
- 효과: `[link text](url)` 같은 마크다운 링크가 엔트리로 오분류되는 edge case 방지

### 2. flatten 강화 (`client.ts`)
- Before: `/\n+/g` — LF만 처리
- After: `/[\r\n]+/g` — CR+LF도 처리

### 3. orphan line 처리
- 타임스탬프 엔트리가 나오기 전의 고아 라인은 drop (기존: 별도 엔트리로 추가)

## 핵심 조치

**머지 후 반드시 `tsc` 빌드 + `mococo restart` 필요.**
현재 실행 중인 봇의 dist에는 PR #12 수정 사항이 미반영 상태.

## 빌드
`tsc --noEmit` 통과

🤖 Generated with [Claude Code](https://claude.com/claude-code)