### PR TITLE
fix. 에러 핸들러 중복 등록 이슈 수정

### DIFF
--- a/src/bot/client.ts
+++ b/src/bot/client.ts
@@ -349,6 +349,8 @@ export async function createBots(config: TeamsConfig, env: EnvConfig): Promise<v
   }, 2 * 60_000);
 
   // Forward hook events as team progress in Discord
+  // Remove previous listeners to prevent accumulation on repeated createBots() calls
+  hookEvents.removeAllListeners('any');
   hookEvents.on('any', async (event) => {
     const team = event.mococo_team ? config.teams[event.mococo_team as string] : null;
     if (!team) return;

--- a/src/orchestrator/gemini-engine.ts
+++ b/src/orchestrator/gemini-engine.ts
@@ -35,12 +35,7 @@ export class GeminiEngine extends BaseEngine {
     });
 
     this.proc.on('error', (err) => {
-      console.error(`[gemini:${this.opts.teamId}] spawn error: ${err.message}`);
-      this.emit('exit', 1);
-    });
-
-    this.proc.on('error', (err) => {
-      console.error(`[GeminiEngine] process error: ${err.message}`);
+      console.error(`[gemini:${this.opts.teamId}] process error: ${err.message}`);
       this.emit('result', { type: 'result', result: `[GeminiEngine] process error: ${err.message}`, total_cost_usd: 0 });
       this.emit('exit', 1);
     });


### PR DESCRIPTION
## Summary
- **GeminiEngine** `.on('error')` 핸들러 2개 → 1개로 통합: 에러 발생 시 `emit('exit', 1)` 2회 호출 및 로그 중복 해소
- **hookEvents** `createBots()` 재호출 시 `'any'` 리스너 누적 방지: `removeAllListeners('any')` 추가

## 변경 파일
| 파일 | 변경 내용 |
|------|-----------|
| `src/orchestrator/gemini-engine.ts` | 중복 error 핸들러 제거, 단일 핸들러로 통합 |
| `src/bot/client.ts` | hookEvents 리스너 등록 전 기존 리스너 제거 |

## Test plan
- [ ] `tsc` 빌드 통과 확인 ✅
- [ ] GeminiEngine spawn 에러 시 로그 1회만 출력되는지 확인
- [ ] 봇 재시작 후 hookEvents 리스너 누적 없는지 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)