### PR TITLE
fix. 리더 트리거 지연 수정 — busy 시 큐 추가 + heartbeat 3분

### DIFF
--- a/src/bot/inbox-compactor.ts
+++ b/src/bot/inbox-compactor.ts
@@ -19,7 +19,7 @@ function isOccupied(teamId: string): boolean {
 
 const PENDING_TASK_INTERVAL_MS = 60_000;
 const DEBOUNCE_MS = 2_000;
-const HEARTBEAT_MS = 10 * 60_000;       // 10 minutes
+const HEARTBEAT_MS = 3 * 60_000;        // 3 minutes
 const FOLLOW_UP_MS = 2 * 60_000;         // 2 minutes
 const DAILY_DIGEST_MS = 24 * 60 * 60_000; // 24 hours
 const PENDING_TASK_COOLDOWN_MS = 2 * 60 * 60_000; // 2 hours cooldown per team
@@ -498,7 +498,7 @@ export function startInboxCompactor(
   env: EnvConfig,
   triggerInvocation: InvocationHandler,
 ): void {
-  console.log('[inbox-compactor] Started: fs.watch(immediate) + heartbeat(10m/fallback) + follow-up(2m) + pending(60s) + digest(24h)');
+  console.log('[inbox-compactor] Started: fs.watch(immediate) + queue-drain(15s) + heartbeat(3m/fallback) + follow-up(2m) + pending(60s) + digest(24h)');
 
   const leaderTeam = Object.values(config.teams).find(t => t.isLeader);
   if (!leaderTeam) {
@@ -511,6 +511,7 @@ export function startInboxCompactor(
   fs.mkdirSync(inboxDir, { recursive: true });
 
   let debounceTimer: NodeJS.Timeout | null = null;
+  let pendingInboxInvoke = false;
 
   const executeHeartbeat = () => {
     leaderHeartbeat(config, env, triggerInvocation).catch(err => {
@@ -521,10 +522,12 @@ export function startInboxCompactor(
   // fs.watch for immediate inbox change detection — A안: bypass haiku triage
   const immediateLeaderInvoke = async () => {
     if (isOccupied(leaderTeam.id)) {
-      console.log('[inbox-compactor] Leader busy/queued, skipping immediate invoke');
+      console.log('[inbox-compactor] Leader busy/queued, queueing inbox invoke');
+      pendingInboxInvoke = true;
       return;
     }
 
+    pendingInboxInvoke = false;
     const inboxPath = path.resolve(ws, '.mococo/inbox', `${leaderTeam.id}.md`);
     let inbox = '';
     try { inbox = fs.readFileSync(inboxPath, 'utf-8').trim(); } catch {}
@@ -566,8 +569,16 @@ export function startInboxCompactor(
     console.error(`[inbox-compactor] Failed to watch inbox directory: ${err}`);
   }
 
-  // Leader heartbeat: periodic check every 10 minutes
+  // Leader heartbeat: periodic check every 3 minutes
   activeTimers.push(setInterval(executeHeartbeat, HEARTBEAT_MS));
+
+  // Queue drain: retry pending inbox invoke every 15 seconds when leader was busy
+  activeTimers.push(setInterval(() => {
+    if (!pendingInboxInvoke) return;
+    immediateLeaderInvoke().catch(err => {
+      console.error(`[inbox-compactor] Queue drain error: ${err}`);
+    });
+  }, 15_000));
 
   // Follow-up loop: check dispatch ledger every 2 minutes
   activeTimers.push(setInterval(() => {


### PR DESCRIPTION
## Summary
- 리더(대장코코)가 busy 상태일 때 inbox 변경 감지 시 invoke를 drop하던 것을 큐에 추가하도록 변경
- 15초 간격 큐 드레인 타이머로 리더 가용 시 즉시 재시도
- heartbeat fallback 주기 10분 → 3분으로 단축

## 변경 사항
- `inbox-compactor.ts`: `pendingInboxInvoke` 플래그 추가, busy 시 큐잉, 15초 드레인 인터벌

## 배경
- 04:30~04:33 대장코코 응답 지연 발생 — busy 상태에서 inbox 변경이 drop되어 heartbeat(10분)까지 대기
- 최악의 경우 최대 10분 지연 → 수정 후 최대 15초 지연으로 개선

## Test plan
- [ ] 빌드 통과 확인
- [ ] 리더 busy 상태에서 inbox 변경 시 큐잉 로그 확인
- [ ] 리더 가용 후 15초 내 자동 invoke 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)