### PR TITLE
fix. compactEpisodes 손상 라인 self-healing 임계값 제거

### DIFF
--- a/src/bot/memory-consolidator.ts
+++ b/src/bot/memory-consolidator.ts
@@ -162,32 +162,29 @@ async function compactEpisodes(teamId: string, teamName: string, config: TeamsCo
     }
   }
 
-  // 손상된 라인이 있으면 요약 로그 출력
+  // Self-healing: 손상된 라인이 1건이라도 있으면 즉시 제거 + 재분류
   if (malformedCount > 0) {
-    console.warn(`[memory-consolidator] ${teamName}: ${malformedCount}건의 손상된 에피소드 라인 스킵됨 (전체 ${lines.length}건 중)`);
-    // Self-healing: 손상 비율 30% 이상이면 유효한 라인만 유지
-    if (malformedCount / lines.length >= 0.3) {
-      const validLines = lines.filter(l => { try { JSON.parse(l); return true; } catch { return false; } });
+    console.warn(`[memory-consolidator] ${teamName}: ${malformedCount}건의 손상된 에피소드 라인 발견 (전체 ${lines.length}건 중)`);
+    const validLines = lines.filter(l => { try { JSON.parse(l); return true; } catch { return false; } });
+    try {
+      atomicWriteSync(filePath, validLines.join('\n') + '\n');
+      console.log(`[memory-consolidator] ${teamName}: Self-healing — ${malformedCount}건 손상 라인 제거, ${validLines.length}건 유지`);
+    } catch (err) {
+      console.error(`[memory-consolidator] ${teamName}: Self-healing write failed: ${err instanceof Error ? err.message : err}`);
+    }
+    // 유효한 라인만으로 재분류
+    old.length = 0;
+    recent.length = 0;
+    for (const line of validLines) {
       try {
-        atomicWriteSync(filePath, validLines.join('\n') + '\n');
-        console.log(`[memory-consolidator] ${teamName}: Self-healing — ${malformedCount}건 손상 라인 제거, ${validLines.length}건 유지`);
-      } catch (err) {
-        console.error(`[memory-consolidator] ${teamName}: Self-healing write failed: ${err instanceof Error ? err.message : err}`);
-      }
-      // 유효한 라인만으로 재분류
-      old.length = 0;
-      recent.length = 0;
-      for (const line of validLines) {
-        try {
-          const ep: Episode = JSON.parse(line);
-          if (now - ep.ts > EPISODE_AGE_THRESHOLD_MS) {
-            old.push(ep);
-          } else {
-            recent.push(line);
-          }
-        } catch {
-          // already filtered
+        const ep: Episode = JSON.parse(line);
+        if (now - ep.ts > EPISODE_AGE_THRESHOLD_MS) {
+          old.push(ep);
+        } else {
+          recent.push(line);
         }
+      } catch {
+        // already filtered
       }
     }
   }


### PR DESCRIPTION
## Summary
- `compactEpisodes`에서 손상된 에피소드 라인 self-healing의 30% 임계값 조건 제거
- `malformedCount > 0`이면 **항상** 손상 라인 제거 + 파일 재작성 + 재분류
- `old.length < 2` early return은 유지

## Bug
손상 라인이 30% 미만 + 오래된 에피소드 < 2건일 때 self-healing이 트리거되지 않아 손상 라인이 파일에 영구 잔류하는 버그

## Test plan
- [ ] 손상 라인 1건 + old 에피소드 0건 → 손상 라인 제거 확인
- [ ] 손상 라인 1건 + old 에피소드 3건 → 손상 라인 제거 + 통합 요약 정상 동작 확인
- [ ] 손상 라인 0건 → 기존 동작 그대로 유지 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)