### PR TITLE
fix. Engine process timeout 추가 (Gemini/Codex/invokeTeam)

### DIFF
--- a/src/orchestrator/codex-engine.ts
+++ b/src/orchestrator/codex-engine.ts
@@ -2,8 +2,13 @@ import { spawn, type ChildProcess } from 'node:child_process';
 import readline from 'node:readline';
 import { BaseEngine } from './engine-base.js';
 
+const PROCESS_TIMEOUT_MS = 5 * 60 * 1000; // 5 minutes
+const SIGKILL_GRACE_MS = 10 * 1000;        // 10 seconds after SIGTERM
+
 export class CodexEngine extends BaseEngine {
   private proc: ChildProcess | null = null;
+  private timeoutTimer: ReturnType<typeof setTimeout> | null = null;
+  private killTimer: ReturnType<typeof setTimeout> | null = null;
 
   async start(): Promise<void> {
     console.log(`[codex:${this.opts.teamId}] Starting codex (model: ${this.opts.model})`);
@@ -19,6 +24,20 @@ export class CodexEngine extends BaseEngine {
       env: this.getTeamEnv(),
       stdio: ['ignore', 'pipe', 'pipe'],
     });
+
+    // Process-level timeout: SIGTERM → SIGKILL escalation
+    this.timeoutTimer = setTimeout(() => {
+      if (this.proc && !this.proc.killed) {
+        console.warn(`[codex:${this.opts.teamId}] process timeout (${PROCESS_TIMEOUT_MS / 1000}s) — sending SIGTERM`);
+        this.proc.kill('SIGTERM');
+        this.killTimer = setTimeout(() => {
+          if (this.proc && !this.proc.killed) {
+            console.warn(`[codex:${this.opts.teamId}] SIGTERM grace period expired — sending SIGKILL`);
+            this.proc.kill('SIGKILL');
+          }
+        }, SIGKILL_GRACE_MS);
+      }
+    }, PROCESS_TIMEOUT_MS);
 
     const messages: string[] = [];
     const stdoutRl = readline.createInterface({ input: this.proc.stdout! });
@@ -41,10 +60,12 @@ export class CodexEngine extends BaseEngine {
     });
 
     this.proc.on('error', (err) => {
+      this.clearTimers();
       console.error(`[codex:${this.opts.teamId}] spawn error: ${err.message}`);
     });
 
     this.proc.on('exit', (code) => {
+      this.clearTimers();
       const output = messages.join('\n').trim();
       console.log(`[codex:${this.opts.teamId}] exited with code ${code} (output: ${output.length} chars)`);
       this.emit('result', { type: 'result', result: output, total_cost_usd: 0 });
@@ -53,6 +74,12 @@ export class CodexEngine extends BaseEngine {
   }
 
   kill() {
+    this.clearTimers();
     this.proc?.kill('SIGTERM');
+  }
+
+  private clearTimers() {
+    if (this.timeoutTimer) { clearTimeout(this.timeoutTimer); this.timeoutTimer = null; }
+    if (this.killTimer) { clearTimeout(this.killTimer); this.killTimer = null; }
   }
 }

--- a/src/orchestrator/gemini-engine.ts
+++ b/src/orchestrator/gemini-engine.ts
@@ -1,8 +1,13 @@
 import { spawn, type ChildProcess } from 'node:child_process';
 import { BaseEngine } from './engine-base.js';
 
+const PROCESS_TIMEOUT_MS = 5 * 60 * 1000; // 5 minutes
+const SIGKILL_GRACE_MS = 10 * 1000;        // 10 seconds after SIGTERM
+
 export class GeminiEngine extends BaseEngine {
   private proc: ChildProcess | null = null;
+  private timeoutTimer: ReturnType<typeof setTimeout> | null = null;
+  private killTimer: ReturnType<typeof setTimeout> | null = null;
 
   async start(): Promise<void> {
     try {
@@ -20,6 +25,20 @@ export class GeminiEngine extends BaseEngine {
       return;
     }
 
+    // Process-level timeout: SIGTERM → SIGKILL escalation
+    this.timeoutTimer = setTimeout(() => {
+      if (this.proc && !this.proc.killed) {
+        console.warn(`[gemini:${this.opts.teamId}] process timeout (${PROCESS_TIMEOUT_MS / 1000}s) — sending SIGTERM`);
+        this.proc.kill('SIGTERM');
+        this.killTimer = setTimeout(() => {
+          if (this.proc && !this.proc.killed) {
+            console.warn(`[gemini:${this.opts.teamId}] SIGTERM grace period expired — sending SIGKILL`);
+            this.proc.kill('SIGKILL');
+          }
+        }, SIGKILL_GRACE_MS);
+      }
+    }, PROCESS_TIMEOUT_MS);
+
     const MAX_STDOUT = 5 * 1024 * 1024; // 5MB
     let stdout = '';
     let stdoutTruncated = false;
@@ -35,18 +54,26 @@ export class GeminiEngine extends BaseEngine {
     });
 
     this.proc.on('error', (err) => {
+      this.clearTimers();
       console.error(`[gemini:${this.opts.teamId}] process error: ${err.message}`);
       this.emit('result', { type: 'result', result: `[GeminiEngine] process error: ${err.message}`, total_cost_usd: 0 });
       this.emit('exit', 1);
     });
 
     this.proc.on('exit', (code) => {
+      this.clearTimers();
       this.emit('result', { type: 'result', result: stdout.trim(), total_cost_usd: 0 });
       this.emit('exit', code);
     });
   }
 
   kill() {
+    this.clearTimers();
     this.proc?.kill('SIGTERM');
+  }
+
+  private clearTimers() {
+    if (this.timeoutTimer) { clearTimeout(this.timeoutTimer); this.timeoutTimer = null; }
+    if (this.killTimer) { clearTimeout(this.killTimer); this.killTimer = null; }
   }
 }

--- a/src/teams/invoker.ts
+++ b/src/teams/invoker.ts
@@ -2,6 +2,8 @@ import { createEngine } from '../orchestrator/engines.js';
 import { buildTeamPrompt } from '../orchestrator/prompt-builder.js';
 import type { TeamConfig, TeamsConfig, TeamInvocation } from '../types.js';
 
+const INVOKE_TIMEOUT_MS = 6 * 60 * 1000; // 6 minutes — safety net above engine-level timeout
+
 export interface InvocationResult {
   teamId: string;
   output: string;
@@ -27,7 +29,7 @@ export async function invokeTeam(
     mcpServers: team.mcpServers,
   });
 
-  return new Promise((resolve, reject) => {
+  const enginePromise = new Promise<InvocationResult>((resolve, reject) => {
     let resolved = false;
 
     engine.on('result', (event) => {
@@ -47,4 +49,13 @@ export async function invokeTeam(
 
     engine.start().catch(reject);
   });
+
+  const timeoutPromise = new Promise<never>((_, reject) => {
+    setTimeout(() => {
+      engine.kill();
+      reject(new Error(`Team ${team.id} (${team.engine}) timed out after ${INVOKE_TIMEOUT_MS / 1000}s`));
+    }, INVOKE_TIMEOUT_MS);
+  });
+
+  return Promise.race([enginePromise, timeoutPromise]);
 }


### PR DESCRIPTION
## Summary
- GeminiEngine/CodexEngine에 5분 process-level timeout 추가 (SIGTERM → 10초 후 SIGKILL escalation)
- invokeTeam에 6분 Promise.race timeout 안전망 추가
- Gemini/Codex CLI 무응답 시 팀 스레드 영구 블록 + typing 무한 루프 방지

## 변경 파일
- `src/orchestrator/gemini-engine.ts` — process timeout + SIGTERM/SIGKILL escalation
- `src/orchestrator/codex-engine.ts` — 동일 패턴 적용
- `src/teams/invoker.ts` — Promise.race timeout 안전망 (engine timeout 실패 시 최종 방어)

## 설계
- **1차 방어 (engine-level, 5분):** 각 engine이 자체 setTimeout으로 프로세스 kill
- **2차 방어 (invoker-level, 6분):** engine timeout이 작동하지 않을 경우를 대비한 Promise.race
- ClaudeEngine은 `--max-budget-usd`로 자연 종료 메커니즘이 있어 이번 변경 대상 아님

## Test plan
- [ ] TypeScript 빌드 통과 확인
- [ ] GeminiEngine timeout 로직 코드 리뷰
- [ ] CodexEngine timeout 로직 코드 리뷰
- [ ] invokeTeam Promise.race 안전망 검증
- [ ] 타이머 정리(clearTimers) 정상 동작 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)