### PR TITLE
fix. MEMORY/PERSONA 블록 Discord 노출 방지 정규식 강화

### DIFF
--- a/src/bot/client.ts
+++ b/src/bot/client.ts
@@ -247,9 +247,9 @@ const registry = new ResourceRegistry();
 
 // Safety-net: strip any internal command blocks that should never reach Discord
 const INTERNAL_BLOCK_PATTERNS = [
-  /(?:```\s*\n?)?(?:\[discord:edit-memory\]\s*\n)?-{3,}MEMORY-{3,}\s*\n[\s\S]*?\n-{3,}END-MEMORY-{3,}(?:\s*\n?```)?/g,
-  /(?:```\s*\n?)?(?:\[discord:edit-long-memory\]\s*\n)?-{3,}LONG-MEMORY-{3,}\s*\n[\s\S]*?\n-{3,}END-LONG-MEMORY-{3,}(?:\s*\n?```)?/g,
-  /(?:```\s*\n?)?(?:\[discord:edit-persona\]\s*\n)?-{3,}PERSONA-{3,}\s*\n[\s\S]*?\n-{3,}END-PERSONA-{3,}(?:\s*\n?```)?/g,
+  /(?:```\s*\n?)?(?:\[discord:edit-memory\]\s*\n)?-{3,}\s*\n?\s*MEMORY\s*-{3,}\s*\n[\s\S]*?\n\s*-{3,}\s*\n?\s*END-MEMORY\s*-{3,}(?:\s*\n?```)?/g,
+  /(?:```\s*\n?)?(?:\[discord:edit-long-memory\]\s*\n)?-{3,}\s*\n?\s*LONG-MEMORY\s*-{3,}\s*\n[\s\S]*?\n\s*-{3,}\s*\n?\s*END-LONG-MEMORY\s*-{3,}(?:\s*\n?```)?/g,
+  /(?:```\s*\n?)?(?:\[discord:edit-persona\]\s*\n)?-{3,}\s*\n?\s*PERSONA\s*-{3,}\s*\n[\s\S]*?\n\s*-{3,}\s*\n?\s*END-PERSONA\s*-{3,}(?:\s*\n?```)?/g,
 ];
 
 function sanitizeForDiscord(text: string): string {

--- a/src/bot/discord-commands.ts
+++ b/src/bot/discord-commands.ts
@@ -7,9 +7,9 @@ import type { TeamConfig, TeamsConfig, EnvConfig } from '../types.js';
 // Strip memory/persona blocks — extracts content, saves to file, then strips
 // ---------------------------------------------------------------------------
 
-const MEMORY_PATTERN = /(?:```\s*\n?)?(?:\[discord:edit-memory\]\s*\n)?---MEMORY---\n([\s\S]*?)\n---END-MEMORY---(?:\s*\n?```)?/g;
-const LONG_MEMORY_PATTERN = /(?:```\s*\n?)?(?:\[discord:edit-long-memory\]\s*\n)?---LONG-MEMORY---\n([\s\S]*?)\n---END-LONG-MEMORY---(?:\s*\n?```)?/g;
-const PERSONA_PATTERN = /(?:```\s*\n?)?(?:\[discord:edit-persona\]\s*\n)?---PERSONA---\n([\s\S]*?)\n---END-PERSONA---(?:\s*\n?```)?/g;
+const MEMORY_PATTERN = /(?:```\s*\n?)?(?:\[discord:edit-memory\]\s*\n)?-{3,}\s*\n?\s*MEMORY\s*-{3,}\s*\n([\s\S]*?)\n\s*-{3,}\s*\n?\s*END-MEMORY\s*-{3,}(?:\s*\n?```)?/g;
+const LONG_MEMORY_PATTERN = /(?:```\s*\n?)?(?:\[discord:edit-long-memory\]\s*\n)?-{3,}\s*\n?\s*LONG-MEMORY\s*-{3,}\s*\n([\s\S]*?)\n\s*-{3,}\s*\n?\s*END-LONG-MEMORY\s*-{3,}(?:\s*\n?```)?/g;
+const PERSONA_PATTERN = /(?:```\s*\n?)?(?:\[discord:edit-persona\]\s*\n)?-{3,}\s*\n?\s*PERSONA\s*-{3,}\s*\n([\s\S]*?)\n\s*-{3,}\s*\n?\s*END-PERSONA\s*-{3,}(?:\s*\n?```)?/g;
 
 export function stripMemoryBlocks(
   output: string,


### PR DESCRIPTION
## Summary
- AI 모델이 `---`와 `MEMORY`를 별도 줄로 출력하거나 공백을 포함하는 경우 기존 정규식이 매칭하지 못해 내부 메모리 블록(`---MEMORY---...---END-MEMORY---`)이 Discord 채팅에 그대로 노출되는 문제 수정
- `discord-commands.ts`(1차 처리)와 `client.ts`(safety net) 양쪽 모두 정규식 패턴 개선
- MEMORY, LONG-MEMORY, PERSONA 블록 모두 동일하게 적용

## Changes
- **대시 수**: `---` 고정 → `-{3,}` (3개 이상)
- **줄바꿈/공백**: `---MEMORY---` 연속 → `---\s*\n?\s*MEMORY\s*---` (줄바꿈, 공백 허용)
- **END 마커**: 동일한 유연화 적용

## Test
```
Case1 (표준): ---MEMORY---\n...\n---END-MEMORY--- ✅
Case2 (분리): ---\nMEMORY---\n...\n---\nEND-MEMORY--- ✅
Case3 (공백): --- MEMORY ---\n...\n--- END-MEMORY --- ✅
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)