### PR TITLE
feat. invokeTeam 타임아웃 10분 연장 및 timeout continuation 추가

### DIFF
--- a/src/bot/client.ts
+++ b/src/bot/client.ts
@@ -786,6 +786,27 @@ export async function handleTeamInvocation(
   markBusy(team.id, triggerMsg.content.slice(0, 50));
   console.log(`[${team.name}] Invoking (chain: ${chain.totalInvocations}/${chain.maxBudget}, trigger: ${triggerMsg.content.slice(0, 80)})`);
 
+  try {
+    await executeInvocation(team, triggerMsg, channelId, config, env, chain, continuationCount);
+  } finally {
+    markFree(team.id);
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Inner invocation logic — separated so timeout continuations can recurse
+// directly while the team stays busy (no markFree/markBusy gap = no race).
+// ---------------------------------------------------------------------------
+
+async function executeInvocation(
+  team: TeamConfig,
+  triggerMsg: ConversationMessage,
+  channelId: string,
+  config: TeamsConfig,
+  env: EnvConfig,
+  chain: ChainContext,
+  continuationCount: number,
+): Promise<void> {
   // Pre-read and atomically clear inbox for leader to prevent data loss.
   // Messages arriving during engine execution go to a fresh file and survive.
   let preloadedInbox: string | undefined;
@@ -819,10 +840,10 @@ export async function handleTeamInvocation(
 
     console.log(`[${team.name}] Done (output: ${result.output ? result.output.length + ' chars' : 'empty'}, cost: $${result.cost.toFixed(4)}${result.timedOut ? ', TIMED OUT' : ''})`);
 
-    // Handle timeout continuation — re-invoke with inbox context
+    // Handle timeout continuation — recurse directly while team stays busy
     if (result.timedOut) {
       if (continuationCount < MAX_TIMEOUT_CONTINUATIONS) {
-        console.log(`[${team.name}] Timeout detected, scheduling continuation (${continuationCount + 1}/${MAX_TIMEOUT_CONTINUATIONS})`);
+        console.log(`[${team.name}] Timeout detected, continuing (${continuationCount + 1}/${MAX_TIMEOUT_CONTINUATIONS})`);
         await appendToInbox(
           team.id,
           'System',
@@ -830,18 +851,19 @@ export async function handleTeamInvocation(
           config.workspacePath,
           channelId,
         ).catch(() => {});
-        // Re-invoke with incremented continuation count (runs after markFree in finally block)
-        setTimeout(() => {
-          const continuationMsg: ConversationMessage = {
-            teamId: 'system',
-            teamName: 'System',
-            content: `[보고 요청] 이전 작업 결과를 보고해주세요. 작업 내용: ${triggerMsg.content.slice(0, 200)}`,
-            timestamp: new Date(),
-            mentions: [team.id],
-          };
-          handleTeamInvocation(team, continuationMsg, channelId, config, env, chain, continuationCount + 1);
-        }, 3_000); // 3s delay to let markFree complete
-        return; // Skip normal output processing
+
+        // Update busy status for observability
+        markBusy(team.id, `continuation ${continuationCount + 1}/${MAX_TIMEOUT_CONTINUATIONS}`);
+
+        const continuationMsg: ConversationMessage = {
+          teamId: 'system',
+          teamName: 'System',
+          content: `[보고 요청] 이전 작업 결과를 보고해주세요. 작업 내용: ${triggerMsg.content.slice(0, 200)}`,
+          timestamp: new Date(),
+          mentions: [team.id],
+        };
+        // Direct recursion — team stays busy, no markFree gap = no race with external triggers
+        return executeInvocation(team, continuationMsg, channelId, config, env, chain, continuationCount + 1);
       }
       console.warn(`[${team.name}] Max continuations reached (${MAX_TIMEOUT_CONTINUATIONS}), not retrying`);
       await sendAsTeam(channelId, team, `작업이 시간 초과되었습니다. 다음 호출 시 메모리에서 이어서 작업합니다.`).catch(() => {});
@@ -942,7 +964,6 @@ export async function handleTeamInvocation(
     await sendAsTeam(channelId, team, `Error: ${errorMsg}`).catch(() => {});
   } finally {
     clearInterval(typingInterval);
-    markFree(team.id);
   }
 }
 

--- a/src/teams/invoker.ts
+++ b/src/teams/invoker.ts
@@ -30,6 +30,14 @@ export async function invokeTeam(
     mcpServers: team.mcpServers,
   });
 
+  // Track last known cost from engine messages so timeout can report actual spend
+  let lastKnownCost = 0;
+  engine.on('message', (event) => {
+    if (typeof event.total_cost_usd === 'number') {
+      lastKnownCost = event.total_cost_usd;
+    }
+  });
+
   const enginePromise = new Promise<InvocationResult>((resolve, reject) => {
     let resolved = false;
 
@@ -54,11 +62,11 @@ export async function invokeTeam(
   const timeoutPromise = new Promise<InvocationResult>((resolve) => {
     setTimeout(() => {
       engine.kill();
-      console.warn(`[${team.id}] Timed out after ${INVOKE_TIMEOUT_MS / 1000}s — returning partial result for continuation`);
+      console.warn(`[${team.id}] Timed out after ${INVOKE_TIMEOUT_MS / 1000}s (cost so far: $${lastKnownCost.toFixed(4)}) — returning partial result for continuation`);
       resolve({
         teamId: team.id,
         output: '',
-        cost: 0,
+        cost: lastKnownCost,
         timedOut: true,
       });
     }, INVOKE_TIMEOUT_MS);


### PR DESCRIPTION
## Summary
- `INVOKE_TIMEOUT_MS` 6분 → 10분으로 연장 (복잡한 작업 처리 시간 확보)
- 타임아웃 발생 시 자동 continuation 메커니즘 추가:
  - 타임아웃 → inbox에 "[시간 초과]" 메시지 작성 → 3초 후 자동 재호출
  - 재호출 시 에이전트가 Short-term Memory 기반으로 이어서 작업
  - 무한 재시도 방지: `MAX_TIMEOUT_CONTINUATIONS = 1` (최대 1회 continuation)

## 변경 파일
- `src/teams/invoker.ts` — 타임아웃 10분 + `timedOut` 플래그 resolve
- `src/bot/client.ts` — continuation 로직 (inbox 메시지 + 재호출)

## Test plan
- [ ] 정상 완료 시 기존 동작 유지 확인
- [ ] 타임아웃 발생 시 continuation 재호출 동작 확인
- [ ] MAX_TIMEOUT_CONTINUATIONS 초과 시 재시도 중단 확인
- [ ] 타입 체크 (`tsc --noEmit`) 통과 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)