### PR TITLE
fix. parseConsolidateResult 파싱 실패 시 메모리 데이터 손실 방지

### DIFF
--- a/src/bot/memory-consolidator.ts
+++ b/src/bot/memory-consolidator.ts
@@ -59,14 +59,14 @@ function parseConsolidateResult(stdout: string): { longTerm: string; shortTerm: 
   const longMatch = stdout.match(/---LONG-TERM---\n([\s\S]*?)\n---END-LONG-TERM---/);
   const shortMatch = stdout.match(/---SHORT-TERM---\n([\s\S]*?)\n---END-SHORT-TERM---/);
 
-  if (!longMatch && !shortMatch) {
-    console.warn(`[memory-consolidator] Could not parse consolidation output (${stdout.length} chars), skipping`);
+  if (!longMatch || !shortMatch) {
+    console.warn(`[memory-consolidator] Could not parse consolidation output — longTerm:${!!longMatch} shortTerm:${!!shortMatch} (${stdout.length} chars), skipping`);
     return null;
   }
 
   return {
-    longTerm: longMatch?.[1]?.trim() ?? '',
-    shortTerm: shortMatch?.[1]?.trim() ?? '',
+    longTerm: longMatch[1].trim(),
+    shortTerm: shortMatch[1].trim(),
   };
 }
 


### PR DESCRIPTION
## Summary
- `parseConsolidateResult`에서 `longMatch` 또는 `shortMatch` 중 하나만 파싱 실패 시 해당 메모리가 빈 문자열로 덮어씌워지는 고위험 데이터 손실 버그 수정
- 조건: `!longMatch && !shortMatch` → `!longMatch || !shortMatch` 로 변경하여 양쪽 모두 파싱 성공해야만 결과 반환
- 실패 시 기존 메모리 유지 (null 반환 → consolidation 스킵)

## Test plan
- [ ] Haiku가 LONG-TERM 섹션만 반환하고 SHORT-TERM 누락 시 → null 반환, 기존 메모리 보존 확인
- [ ] Haiku가 SHORT-TERM 섹션만 반환하고 LONG-TERM 누락 시 → null 반환, 기존 메모리 보존 확인
- [ ] 정상 출력 (양쪽 모두 있음) → 정상 파싱 및 메모리 업데이트 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)