### PR TITLE
fix. heartbeat dedup — 동일 오탐 반복 INVOKE 방지

### DIFF
--- a/src/bot/inbox-compactor.ts
+++ b/src/bot/inbox-compactor.ts
@@ -50,6 +50,11 @@ const MAX_NUDGES_PER_RECORD = 2;
 const followUpCooldowns = new Map<string, number>();
 const FOLLOW_UP_COOLDOWN_MS = 30 * 60_000; // 30 minutes cooldown per team
 
+// Heartbeat dedup — suppress repeated invocations for identical context
+const HEARTBEAT_DEDUP_WINDOW_MS = 60 * 60_000; // 1 hour suppression window
+let lastHeartbeatFingerprint: string | null = null;
+let lastHeartbeatInvokeAt = 0;
+
 function isFollowUpOnCooldown(teamId: string): boolean {
   const lastNudge = followUpCooldowns.get(teamId);
   if (!lastNudge) return false;
@@ -125,6 +130,7 @@ async function leaderHeartbeat(
     try { inbox = fs.readFileSync(inboxPath, 'utf-8').trim(); } catch {}
 
     const unresolved = ledger.getUnresolved(5 * 60_000); // 5min+
+    const highIssueKeys: string[] = []; // for heartbeat dedup fingerprint
 
     let improvementReport: string | null = null;
     try {
@@ -178,6 +184,7 @@ async function leaderHeartbeat(
           lines.push('--- high ---');
           for (const i of high) {
             lines.push(`- [${i.type}] ${i.repo}/${i.file}: ${i.description}`);
+            highIssueKeys.push(`${i.repo}/${i.file}:${i.type}`);
           }
         }
         if (medium.length > 0) {
@@ -204,6 +211,18 @@ async function leaderHeartbeat(
 
     // Nothing to evaluate
     if (!inbox && unresolved.length === 0 && !improvementReport) return;
+
+    // Dedup check — suppress if same dispatches + issues were already reported recently
+    const heartbeatFp = [
+      ...unresolved.map(r => r.id).sort(),
+      '||',
+      ...highIssueKeys.sort(),
+    ].join('|');
+
+    if (!inbox && heartbeatFp === lastHeartbeatFingerprint && Date.now() - lastHeartbeatInvokeAt < HEARTBEAT_DEDUP_WINDOW_MS) {
+      console.log('[heartbeat] Suppressed: identical context already reported within dedup window');
+      return;
+    }
 
     // Haiku triage
     const triagePrompt = buildTriagePrompt(inbox, unresolved.length, improvementReport);
@@ -234,6 +253,9 @@ async function leaderHeartbeat(
     };
     addMessage(channelId, systemMsg);
     triggerInvocation(leaderTeam, systemMsg, channelId, config, env, newChain());
+    // Update heartbeat dedup state
+    lastHeartbeatFingerprint = heartbeatFp;
+    lastHeartbeatInvokeAt = Date.now();
     // Inbox is cleared inside handleTeamInvocation after buildTeamPrompt reads it
   } catch (err) {
     console.error(`[heartbeat] Error: ${err}`);


### PR DESCRIPTION
## Summary
- heartbeat가 3분마다 동일한 미해결 디스패치 + improvement issues를 Haiku에 전달 → 매번 INVOKE 판정 → 리더에게 동일 알림 반복 발생
- 미해결 디스패치 ID + high severity 이슈 키를 fingerprint로 추적, 동일 fingerprint가 1시간 dedup 윈도우 내에 재감지되면 suppress
- inbox에 새 메시지가 있을 때는 dedup 무시하여 즉시 처리 보장

## 변경 내용
- `HEARTBEAT_DEDUP_WINDOW_MS` (1시간) 억제 윈도우 추가
- `heartbeatFp` fingerprint: `[...unresolvedIds.sort(), '||', ...highIssueKeys.sort()].join('|')`
- INVOKE 성공 시 fingerprint 저장, 다음 heartbeat에서 동일 fingerprint면 skip
- inbox 변경 시에는 dedup 체크 자체를 건너뜀

## Test plan
- [ ] 빌드 성공 확인 (tsc 통과)
- [ ] 동일 미해결 디스패치가 있을 때 1시간 내 반복 INVOKE가 발생하지 않는지 확인
- [ ] inbox에 새 메시지 도착 시 dedup 무시하고 정상 INVOKE 되는지 확인
- [ ] 새로운 디스패치 추가 시 fingerprint 변경으로 정상 INVOKE 되는지 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)