### PR TITLE
refactor. open-source Phase 1 — remove hardcoded branding

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,21 @@
+# Discord work channel ID (leave empty for all channels)
+WORK_CHANNEL_ID=
+
+# HTTP webhook receiver port
+HOOK_PORT=9876
+
+# Optional: channel for member tracking
+# MEMBER_TRACKING_CHANNEL_ID=
+
+# Optional: channel for leader decision logs
+# DECISION_LOG_CHANNEL_ID=
+
+# Discord bot tokens — one per agent
+# Format: {AGENT_ID_UPPERCASE}_DISCORD_TOKEN=your-token-here
+# Example:
+# LEADER_DISCORD_TOKEN=your-leader-bot-token
+# BACKEND_DISCORD_TOKEN=your-backend-bot-token
+# FRONTEND_DISCORD_TOKEN=your-frontend-bot-token
+
+# MCP server credentials (if using MCP integrations)
+# GOOGLE_OAUTH_CREDENTIALS=/path/to/oauth-credentials.json

--- a/defaults/shared-rules.md
+++ b/defaults/shared-rules.md
@@ -1,0 +1,70 @@
+## Common Rules
+
+### Priority
+**Rules > Role > Personality** — Rules always override personality when in conflict.
+On conflict: stop → verify → propose alternative → execute after approval.
+
+### Hierarchy
+{{humanTitle}} > {{leaderName}} > Self. Superiors' instructions always take priority.
+
+### Absolute Prohibitions
+- PR merge — only {{humanTitle}} can do this
+- Exposing tokens, passwords, or credentials
+- Tagging your own Discord ID
+
+### Tag Response Judgment
+Being tagged doesn't always require a response. Judge the context:
+- **Speaking to me** (question, instruction, request) → respond
+- **Merely mentioning me** (talking about me to a third party) → no response needed
+
+### Conversation End Judgment
+Only tag someone when you **have something to say**. End without tagging if:
+- Ceremonial responses (greetings, thanks, acknowledgments) → end without tag
+- Other party already completed/approved and **no further discussion needed** → end
+- **Repeating** the same topic → end
+- No new information, questions, or work to delegate → end
+
+**Principle: Tag = only when the other party needs to take action. A reaction emoji is enough otherwise.**
+
+### {{humanTitle}} Tagging Rules
+Tag {{humanTitle}} **minimally**. Only tag when:
+- Answering {{humanTitle}}'s **direct question/instruction**
+- A matter **requiring approval** (PR merge, critical decisions)
+- An **urgent issue** only {{humanTitle}} can resolve
+
+For other reports, progress updates, general questions → **tag {{leaderName}}**. {{leaderName}} will relay to {{humanTitle}} if needed.
+
+### Behavior Principles
+- **Stop if uncertain** — don't guess, ask {{leaderName}}
+- **Report failures immediately** — explain the situation to {{leaderName}}
+- **Be concise** — Discord messages should be to the point. No essays
+- **When handing off work** — @mention + 1-line summary + background/requirements
+- **Keep casual conversation natural** — In non-work conversations (greetings, welcomes, chat), don't use instructional or explanatory tone. Talk like a person. No directives like "please do X". If you have nothing to say, don't say it.
+
+### Memory Rules
+- **All in-progress tasks and waiting items must include `#ch:channelId`.** The auto-loop needs the channel ID to determine where to continue work.
+- Without a channel ID, the loop may skip or malfunction.
+
+### Default Honorifics
+- {{humanTitle}}: respectful/formal language
+- {{leaderName}}: defined per agent in Character section (default: respectful)
+- Other agents: defined per agent in Character section
+
+### New Agent Welcome Protocol
+When a new agent joins the server, the system generates a `[New Agent Joined]` message.
+Follow this sequence strictly. **Do not tag multiple agents at once.**
+
+**Step 1 — {{leaderName}} (on receiving system message):**
+- Tag **only** the new agent and request an introduction
+- Do not tag other agents at this step
+
+**Step 2 — New agent (when tagged):**
+- Self-introduction: name, role, responsibilities
+- One-liner commitment: how they'll contribute to the team
+- Tag {{leaderName}} to respond (tag rules auto-invoke {{leaderName}})
+
+**Step 3 — {{leaderName}} (after confirming introduction):**
+- Tag other agents and ask them to welcome the newcomer
+
+**Step 4 — Other agents (when tagged):**
+- Welcome message or a welcoming emoji reaction like `[discord:react emoji=👋]`

--- a/src/cli/commands/add.ts
+++ b/src/cli/commands/add.ts
@@ -26,22 +26,22 @@ const PERMISSION_PRESETS: Record<string, { allow?: string[]; deny?: string[] }> 
 const AVATAR_KEYS = ['robot', 'crown', 'brain', 'gear', 'palette', 'shield', 'eye', 'test', 'book'];
 
 const MBTI_PRESETS: Record<string, string> = {
-  'ENTJ — 전략가, 결단력, 큰 그림': 'ENTJ — 전략가, 결단력, 큰 그림을 보는 리더',
-  'ISTJ — 규칙 준수, 체계적, 정확성': 'ISTJ — 규칙 준수, 체계적, 정확성 중시',
-  'ENFJ — 사람 중심, 공감, 조직 조화': 'ENFJ — 사람 중심 사고, 조직 조화, 공감 능력',
-  'INTP — 분석적, 논리적, 탐구형': 'INTP — 분석적, 논리적, 깊이 있는 탐구형',
+  'ENTJ — Strategist, decisive, big-picture leader': 'ENTJ — Strategist, decisive, big-picture leader',
+  'ISTJ — Rule-follower, systematic, accuracy-focused': 'ISTJ — Rule-follower, systematic, accuracy-focused',
+  'ENFJ — People-oriented, empathetic, team harmony': 'ENFJ — People-oriented, empathetic, team harmony',
+  'INTP — Analytical, logical, deep explorer': 'INTP — Analytical, logical, deep explorer',
   'Custom': '',
 };
 
 const SPEECH_PRESETS: Record<string, string> = {
-  '모두 존댓말': [
-    '  - 회장님께: 존댓말. "회장님, ~입니다"',
-    '  - 대장코코에게: 존댓말. "대장님, ~입니다"',
-    '  - 다른 모코코에게: 존댓말. "{이름}코코님"',
+  'Formal to everyone': [
+    '  - To the human: formal and respectful',
+    '  - To the leader: formal and respectful',
+    '  - To other agents: polite and professional',
   ].join('\n'),
-  '회장님 존댓말 + 팀원 반말': [
-    '  - 회장님께: 철저한 존댓말. "회장님, ~입니다", "~드리겠습니다"',
-    '  - 다른 모코코들에게: 반말. "~해라", "~해봐", "~됐어?"',
+  'Formal to human + casual to peers': [
+    '  - To the human: strictly formal and respectful',
+    '  - To other agents: casual and direct',
   ].join('\n'),
   'Custom': '',
 };
@@ -51,7 +51,10 @@ export async function runAdd(): Promise<void> {
   const teamsJsonPath = path.join(ws, 'teams.json');
   const raw = JSON.parse(fs.readFileSync(teamsJsonPath, 'utf-8'));
 
-  console.log('Add a new 모코코\n');
+  // Load humanTitle from config for prompt generation
+  const humanTitle: string = raw.humanTitle ?? 'Boss';
+
+  console.log('Add a new agent\n');
 
   // --- Identity ---
   console.log('── Identity ──');
@@ -65,7 +68,7 @@ export async function runAdd(): Promise<void> {
     process.exit(1);
   }
 
-  const name = await ask('Display name (e.g. HR코코)', id.charAt(0).toUpperCase() + id.slice(1));
+  const name = await ask('Display name (e.g. Backend)', id.charAt(0).toUpperCase() + id.slice(1));
   const isLeader = await confirm('Is this the leader (responds to all messages)?', false);
 
   // --- Character ---
@@ -76,15 +79,15 @@ export async function runAdd(): Promise<void> {
   const mbtiChoice = await choose('MBTI:', mbtiNames, 0);
   let mbti = MBTI_PRESETS[mbtiChoice];
   if (!mbti) {
-    mbti = await ask('MBTI (e.g. ISFJ — 성실, 배려, 실행력)');
+    mbti = await ask('MBTI (e.g. ISFJ — Diligent, caring, executor)');
   }
 
   // Speech style
   const speechNames = Object.keys(SPEECH_PRESETS);
-  const speechChoice = await choose('말투:', speechNames, 0);
+  const speechChoice = await choose('Speech style:', speechNames, 0);
   let speechStyle = SPEECH_PRESETS[speechChoice];
   if (!speechStyle) {
-    console.log('말투를 줄별로 입력 (빈 줄로 종료):');
+    console.log('Enter speech style line by line (empty line to finish):');
     const lines: string[] = [];
     let line = await ask('  ');
     while (line) {
@@ -95,49 +98,49 @@ export async function runAdd(): Promise<void> {
   }
 
   // Traits
-  console.log('성격 특성 (행동 예시 포함, comma-separated):');
-  console.log('  예: "체계적 — 모든 요구사항을 구조화, 신중함 — 확실하지 않으면 확인"');
-  const traitsStr = await ask('  성격', '');
+  console.log('Personality traits (with behavior examples, comma-separated):');
+  console.log('  e.g. "Systematic — structures all requirements, Cautious — verifies when unsure"');
+  const traitsStr = await ask('  Traits', '');
   const traits = traitsStr
     ? traitsStr.split(',').map(s => s.trim()).filter(Boolean)
     : [];
 
   // Habits
-  console.log('습관 (comma-separated):');
-  console.log('  예: "보고 시 결론→근거→다음단계 순서, 위임 시 명령조로 마무리"');
-  const habitsStr = await ask('  습관', '');
+  console.log('Habits (comma-separated):');
+  console.log('  e.g. "Reports in conclusion→evidence→next-steps order, Ends delegations with clear directives"');
+  const habitsStr = await ask('  Habits', '');
   const habits = habitsStr
     ? habitsStr.split(',').map(s => s.trim()).filter(Boolean)
     : [];
 
   // --- Role ---
   console.log('\n── Role ──');
-  const role = await ask('핵심 역할 (1-2문장)');
+  const role = await ask('Core role (1-2 sentences)');
 
-  console.log('담당 범위 (comma-separated):');
-  const scopeStr = await ask('  담당', '');
+  console.log('Scope (comma-separated):');
+  const scopeStr = await ask('  Scope', '');
   const scope = scopeStr
     ? scopeStr.split(',').map(s => s.trim()).filter(Boolean)
     : [];
 
-  console.log('담당 아닌 것 (comma-separated):');
-  const notScopeStr = await ask('  비담당', '');
+  console.log('Not in scope (comma-separated):');
+  const notScopeStr = await ask('  Not in scope', '');
   const notScope = notScopeStr
     ? notScopeStr.split(',').map(s => s.trim()).filter(Boolean)
     : [];
 
-  const authorityIndependent = await ask('독립 결정 가능한 것', '');
-  const authorityNeedsApproval = await ask('승인 필요한 것', '');
+  const authorityIndependent = await ask('Independent decisions', '');
+  const authorityNeedsApproval = await ask('Needs approval for', '');
 
   // Expertise
-  console.log('전문 분야 (comma-separated):');
+  console.log('Expertise (comma-separated):');
   const expertiseStr = await ask('  Expertise', '');
   const expertise = expertiseStr
     ? expertiseStr.split(',').map(s => s.trim()).filter(Boolean)
     : [];
 
   // Custom rules
-  console.log('추가 규칙 (comma-separated):');
+  console.log('Additional rules (comma-separated):');
   const rulesStr = await ask('  Rules', '');
   const rules = rulesStr
     ? rulesStr.split(',').map(s => s.trim()).filter(Boolean)
@@ -182,7 +185,7 @@ export async function runAdd(): Promise<void> {
   // --- Git identity ---
   console.log('\n── Git identity ──');
   const gitName = await ask('Git author name', `${name} (mococo)`);
-  const gitEmail = await ask('Git author email', `mococo-${id}@users.noreply.github.com`);
+  const gitEmail = await ask('Git author email', `${id}@users.noreply.github.com`);
 
   // Pick an avatar
   const usedAvatars = new Set(Object.values(raw.teams as Record<string, any>).map((t: any) => t.avatar));
@@ -220,12 +223,13 @@ export async function runAdd(): Promise<void> {
       role, scope, notScope,
       authorityIndependent, authorityNeedsApproval,
       expertise, rules, isLeader,
+      humanTitle,
     }));
   }
 
-  console.log(`\n모코코 "${name}" (${id}) 추가 완료.`);
+  console.log(`\nAgent "${name}" (${id}) added successfully.`);
   console.log(`  Config:  teams.json`);
-  console.log(`  Prompt:  prompts/${id}.md  (직접 수정 가능)`);
+  console.log(`  Prompt:  prompts/${id}.md  (editable)`);
   console.log(`  Tokens:  .env`);
   console.log(`\nRun \`mococo start\` to launch.`);
 }

--- a/src/cli/commands/edit.ts
+++ b/src/cli/commands/edit.ts
@@ -24,30 +24,30 @@ const PERMISSION_PRESETS: Record<string, { allow?: string[]; deny?: string[] }> 
 };
 
 const MBTI_PRESETS: Record<string, string> = {
-  'ENTJ — 전략가, 결단력, 큰 그림': 'ENTJ — 전략가, 결단력, 큰 그림을 보는 리더',
-  'ISTJ — 규칙 준수, 체계적, 정확성': 'ISTJ — 규칙 준수, 체계적, 정확성 중시',
-  'ENFJ — 사람 중심, 공감, 조직 조화': 'ENFJ — 사람 중심 사고, 조직 조화, 공감 능력',
-  'INTP — 분석적, 논리적, 탐구형': 'INTP — 분석적, 논리적, 깊이 있는 탐구형',
+  'ENTJ — Strategist, decisive, big-picture leader': 'ENTJ — Strategist, decisive, big-picture leader',
+  'ISTJ — Rule-follower, systematic, accuracy-focused': 'ISTJ — Rule-follower, systematic, accuracy-focused',
+  'ENFJ — People-oriented, empathetic, team harmony': 'ENFJ — People-oriented, empathetic, team harmony',
+  'INTP — Analytical, logical, deep explorer': 'INTP — Analytical, logical, deep explorer',
   'Custom': '',
 };
 
 const SPEECH_PRESETS: Record<string, string> = {
-  '모두 존댓말': [
-    '  - 회장님께: 존댓말. "회장님, ~입니다"',
-    '  - 대장코코에게: 존댓말. "대장님, ~입니다"',
-    '  - 다른 모코코에게: 존댓말. "{이름}코코님"',
+  'Formal to everyone': [
+    '  - To the human: formal and respectful',
+    '  - To the leader: formal and respectful',
+    '  - To other agents: polite and professional',
   ].join('\n'),
-  '회장님 존댓말 + 팀원 반말': [
-    '  - 회장님께: 철저한 존댓말. "회장님, ~입니다", "~드리겠습니다"',
-    '  - 다른 모코코들에게: 반말. "~해라", "~해봐", "~됐어?"',
+  'Formal to human + casual to peers': [
+    '  - To the human: strictly formal and respectful',
+    '  - To other agents: casual and direct',
   ].join('\n'),
   'Custom': '',
 };
 
 const EDIT_FIELDS = [
   'name        — Display name',
-  'character   — MBTI, 말투, 성격, 습관',
-  'role        — 담당/비담당/권한',
+  'character   — MBTI, speech style, personality, habits',
+  'role        — Scope, authority, expertise',
   'engine      — Engine and model',
   'budget      — Max budget',
   'channels    — Channel restrictions',
@@ -66,6 +66,9 @@ export async function runEdit(id: string): Promise<void> {
   const teamsJsonPath = path.join(ws, 'teams.json');
   const raw = JSON.parse(fs.readFileSync(teamsJsonPath, 'utf-8'));
   const team = raw.teams[id];
+
+  // Load humanTitle from config for prompt generation
+  const humanTitle: string = raw.humanTitle ?? 'Boss';
 
   if (!team) {
     console.error(`Assistant "${id}" not found.`);
@@ -111,14 +114,14 @@ export async function runEdit(id: string): Promise<void> {
       const mbtiChoice = await choose('MBTI:', mbtiNames, 0);
       mbti = MBTI_PRESETS[mbtiChoice];
       if (!mbti) {
-        mbti = await ask('MBTI (e.g. ISFJ — 성실, 배려, 실행력)');
+        mbti = await ask('MBTI (e.g. ISFJ — Diligent, caring, executor)');
       }
 
       const speechNames = Object.keys(SPEECH_PRESETS);
-      const speechChoice = await choose('말투:', speechNames, 0);
+      const speechChoice = await choose('Speech style:', speechNames, 0);
       speechStyle = SPEECH_PRESETS[speechChoice];
       if (!speechStyle) {
-        console.log('말투를 줄별로 입력 (빈 줄로 종료):');
+        console.log('Enter speech style line by line (empty line to finish):');
         const lines: string[] = [];
         let line = await ask('  ');
         while (line) {
@@ -128,35 +131,35 @@ export async function runEdit(id: string): Promise<void> {
         speechStyle = lines.join('\n');
       }
 
-      console.log('성격 특성 (행동 예시 포함, comma-separated):');
-      const traitsStr = await ask('  성격', '');
+      console.log('Personality traits (with behavior examples, comma-separated):');
+      const traitsStr = await ask('  Traits', '');
       traits = traitsStr ? traitsStr.split(',').map(s => s.trim()).filter(Boolean) : [];
 
-      console.log('습관 (comma-separated):');
-      const habitsStr = await ask('  습관', '');
+      console.log('Habits (comma-separated):');
+      const habitsStr = await ask('  Habits', '');
       habits = habitsStr ? habitsStr.split(',').map(s => s.trim()).filter(Boolean) : [];
     }
 
     if (editAll || field === 'role') {
       console.log('\n── Role ──');
-      role = await ask('핵심 역할 (1-2문장)', '');
+      role = await ask('Core role (1-2 sentences)', '');
 
-      console.log('담당 범위 (comma-separated):');
-      const scopeStr = await ask('  담당', '');
+      console.log('Scope (comma-separated):');
+      const scopeStr = await ask('  Scope', '');
       scope = scopeStr ? scopeStr.split(',').map(s => s.trim()).filter(Boolean) : [];
 
-      console.log('담당 아닌 것 (comma-separated):');
-      const notScopeStr = await ask('  비담당', '');
+      console.log('Not in scope (comma-separated):');
+      const notScopeStr = await ask('  Not in scope', '');
       notScope = notScopeStr ? notScopeStr.split(',').map(s => s.trim()).filter(Boolean) : [];
 
-      authorityIndependent = await ask('독립 결정 가능한 것', '');
-      authorityNeedsApproval = await ask('승인 필요한 것', '');
+      authorityIndependent = await ask('Independent decisions', '');
+      authorityNeedsApproval = await ask('Needs approval for', '');
 
-      console.log('전문 분야 (comma-separated):');
+      console.log('Expertise (comma-separated):');
       const expertiseStr = await ask('  Expertise', '');
       expertise = expertiseStr ? expertiseStr.split(',').map(s => s.trim()).filter(Boolean) : [];
 
-      console.log('추가 규칙 (comma-separated):');
+      console.log('Additional rules (comma-separated):');
       const rulesStr = await ask('  Rules', '');
       rules = rulesStr ? rulesStr.split(',').map(s => s.trim()).filter(Boolean) : [];
 
@@ -168,7 +171,7 @@ export async function runEdit(id: string): Promise<void> {
       }
     }
 
-    regeneratePrompt = await confirm('페르소나 파일 재생성? (기존 파일 덮어쓰기)', true);
+    regeneratePrompt = await confirm('Regenerate persona file? (overwrites existing)', true);
   }
 
   // Engine
@@ -212,7 +215,7 @@ export async function runEdit(id: string): Promise<void> {
   if (editAll || field === 'git') {
     const git = team.git ?? {};
     git.name = await ask('Git author name', git.name ?? `${team.name} (mococo)`);
-    git.email = await ask('Git author email', git.email ?? `mococo-${id}@users.noreply.github.com`);
+    git.email = await ask('Git author email', git.email ?? `${id}@users.noreply.github.com`);
     team.git = git;
   }
 
@@ -227,17 +230,18 @@ export async function runEdit(id: string): Promise<void> {
     const promptPath = path.join(ws, 'prompts', `${id}.md`);
     fs.writeFileSync(promptPath, generatePrompt({
       name: team.name,
-      mbti: mbti || 'MBTI — (직접 작성)',
-      speechStyle: speechStyle || '  - (직접 작성)',
+      mbti: mbti || 'MBTI — (edit manually)',
+      speechStyle: speechStyle || '  - (edit manually)',
       traits, habits,
-      role: role || '(직접 작성)',
+      role: role || '(edit manually)',
       scope, notScope,
       authorityIndependent, authorityNeedsApproval,
       expertise, rules,
       isLeader,
+      humanTitle,
     }));
-    console.log(`  페르소나 재생성: prompts/${id}.md`);
+    console.log(`  Persona regenerated: prompts/${id}.md`);
   }
 
-  console.log(`\n모코코 "${team.name}" (${id}) 수정 완료.`);
+  console.log(`\nAgent "${team.name}" (${id}) updated successfully.`);
 }

--- a/src/cli/commands/init.ts
+++ b/src/cli/commands/init.ts
@@ -28,9 +28,9 @@ export async function runInit(): Promise<void> {
   const isReinit = fs.existsSync(teamsJsonPath);
 
   if (isReinit) {
-    console.log('Existing mococo workspace detected. Updating settings...\n');
+    console.log('Existing workspace detected. Updating settings...\n');
   } else {
-    console.log('Initializing mococo workspace...\n');
+    console.log('Initializing workspace...\n');
   }
 
   const channelId = await ask('Discord work channel ID (leave empty for all channels)');
@@ -83,6 +83,16 @@ export async function runInit(): Promise<void> {
 
   // Ensure directories exist (both fresh and reinit)
   fs.mkdirSync(path.join(cwd, 'prompts'), { recursive: true });
+
+  // Copy default shared-rules.md if not present
+  const sharedRulesPath = path.join(cwd, 'prompts', 'shared-rules.md');
+  if (!fs.existsSync(sharedRulesPath)) {
+    const defaultRules = path.join(getPackageRoot(), 'defaults', 'shared-rules.md');
+    if (fs.existsSync(defaultRules)) {
+      fs.copyFileSync(defaultRules, sharedRulesPath);
+    }
+  }
+
   fs.mkdirSync(path.join(cwd, 'repos'), { recursive: true });
   if (!fs.existsSync(path.join(cwd, 'repos', '.gitkeep'))) {
     fs.writeFileSync(path.join(cwd, 'repos', '.gitkeep'), '');

--- a/src/cli/prompt-template.ts
+++ b/src/cli/prompt-template.ts
@@ -12,24 +12,27 @@ export interface PromptOptions {
   expertise: string[];
   rules: string[];
   isLeader: boolean;
+  humanTitle?: string;
 }
 
 export function generatePrompt(opts: PromptOptions): string {
+  const humanTitle = opts.humanTitle || 'Boss';
+
   const traitsBlock = opts.traits.length > 0
     ? opts.traits.map(t => `  - ${t}`).join('\n')
-    : '  - (페르소나 파일에서 직접 작성)';
+    : '  - (edit in persona file)';
 
   const habitsBlock = opts.habits.length > 0
     ? opts.habits.map(h => `  - ${h}`).join('\n')
-    : '  - (페르소나 파일에서 직접 작성)';
+    : '  - (edit in persona file)';
 
   const scopeBlock = opts.scope.length > 0
     ? opts.scope.map(s => `- ${s}`).join('\n')
-    : '- (페르소나 파일에서 직접 작성)';
+    : '- (edit in persona file)';
 
   const notScopeBlock = opts.notScope.length > 0
     ? opts.notScope.map(s => `- ${s}`).join('\n')
-    : '- (페르소나 파일에서 직접 작성)';
+    : '- (edit in persona file)';
 
   const expertiseBlock = opts.expertise.length > 0
     ? `\n## Expertise\n${opts.expertise.map(e => `- ${e}`).join('\n')}\n`
@@ -37,38 +40,38 @@ export function generatePrompt(opts: PromptOptions): string {
 
   const customRules = opts.rules.length > 0
     ? opts.rules.map(r => `- ${r}`).join('\n')
-    : '- (페르소나 파일에서 직접 작성)';
+    : '- (edit in persona file)';
 
   const leaderExtra = opts.isLeader
-    ? '\n- 채널의 모든 메시지에 반응 (@멘션뿐 아니라 전부)\n- 직접 작업 절대 금지 — 오직 위임과 보고만'
+    ? '\n- Respond to ALL channel messages (not just @mentions)\n- Never work directly — only delegate and report'
     : '';
 
   return `# ${opts.name}
 
 You are **${opts.name}**, an AI assistant on Discord.
-When addressing the human, always call them **회장님**.
+When addressing the human, always call them **${humanTitle}**.
 
 ## Character
 - **MBTI:** ${opts.mbti}
-- **말투:**
+- **Speech style:**
 ${opts.speechStyle}
-- **성격:**
+- **Personality:**
 ${traitsBlock}
-- **습관:**
+- **Habits:**
 ${habitsBlock}
 
 ## Role
 ${opts.role}
 
-**담당:**
+**Scope:**
 ${scopeBlock}
 
-**담당 아님:**
+**Not in scope:**
 ${notScopeBlock}
 
-**결정 권한:**
-- 독립 결정: ${opts.authorityIndependent || '(페르소나 파일에서 직접 작성)'}
-- 승인 필요: ${opts.authorityNeedsApproval || '(페르소나 파일에서 직접 작성)'}
+**Decision authority:**
+- Independent: ${opts.authorityIndependent || '(edit in persona file)'}
+- Needs approval: ${opts.authorityNeedsApproval || '(edit in persona file)'}
 ${expertiseBlock}
 ## Rules${leaderExtra}
 ${customRules}

--- a/src/config.ts
+++ b/src/config.ts
@@ -82,7 +82,7 @@ export function loadTeamsConfig(workspacePath: string = process.cwd()): TeamsCon
       teamRules: cfg.teamRules,
       git: cfg.git ?? {
         name: `${cfg.name} (mococo)`,
-        email: `mococo-${id}@users.noreply.github.com`,
+        email: `${id}@users.noreply.github.com`,
       },
       discordToken,
       mcpServers,
@@ -96,6 +96,7 @@ export function loadTeamsConfig(workspacePath: string = process.cwd()): TeamsCon
     conversationWindow: raw.conversationWindow ?? 30,
     workspacePath,
     humanDiscordId: raw.humanDiscordId,
+    humanTitle: raw.humanTitle ?? 'Boss',
   };
 }
 

--- a/src/orchestrator/prompt-builder.ts
+++ b/src/orchestrator/prompt-builder.ts
@@ -8,7 +8,7 @@ const MAX_INBOX_ENTRIES = 20;
 const MAX_ENTRY_CHARS = 200;
 
 // File cache for rarely-changing files (shared rules, member list)
-// 파일 캐시: mtime + size 모두 비교하여 변경 감지 정확도 향상
+// File cache: compare both mtime + size for accurate change detection
 const fileCache = new Map<string, { content: string; cachedAt: number; size: number; mtimeMs: number }>();
 const CACHE_TTL_MS = 5 * 60_000; // 5 minutes
 
@@ -17,7 +17,7 @@ function readCached(filePath: string): string {
   const cached = fileCache.get(filePath);
 
   if (cached && now - cached.cachedAt < CACHE_TTL_MS) {
-    // TTL 내라도 파일 크기/수정 시간이 변경되었으면 캐시 무효화
+    // Invalidate cache if file size/mtime changed even within TTL
     try {
       const stat = fs.statSync(filePath);
       if (stat.size === cached.size && stat.mtimeMs === cached.mtimeMs) {
@@ -30,7 +30,7 @@ function readCached(filePath: string): string {
   }
 
   try {
-    // 단일 stat 호출로 크기/수정시간 확인 후 내용 읽기 (이중 stat 방지)
+    // Single stat call for size/mtime check then read content (avoid double stat)
     const stat = fs.statSync(filePath);
     const content = fs.readFileSync(filePath, 'utf-8').trim();
     fileCache.set(filePath, { content, cachedAt: now, size: stat.size, mtimeMs: stat.mtimeMs });
@@ -87,9 +87,9 @@ function summarizeInbox(raw: string, teamId: string): string {
       : failedLines.slice(0, 3).map(l => l.slice(0, 80)).join('; ') + '...';
     const failRatio = failedLines.length / merged.length;
     if (failRatio > 0.5) {
-      console.error(`[summarizeInbox] ${teamId}: ${failedLines.length}/${merged.length}건 파싱 실패 (${(failRatio * 100).toFixed(0)}% — 과반 이상) — ${sample}`);
+      console.error(`[summarizeInbox] ${teamId}: ${failedLines.length}/${merged.length} entries failed to parse (${(failRatio * 100).toFixed(0)}% — majority) — ${sample}`);
     } else {
-      console.warn(`[summarizeInbox] ${teamId}: ${failedLines.length}/${merged.length}건 파싱 실패 — ${sample}`);
+      console.warn(`[summarizeInbox] ${teamId}: ${failedLines.length}/${merged.length} entries failed to parse — ${sample}`);
     }
   }
 
@@ -195,81 +195,81 @@ function loadInbox(ws: string, team: TeamConfig, preloadedInbox?: string): strin
 // Prompt section builders
 // ---------------------------------------------------------------------------
 
-function buildMemorySection(longTerm: string, shortTerm: string, chId: string): string {
+function buildMemorySection(longTerm: string, shortTerm: string, chId: string, humanTitle: string): string {
   return `## Long-term Memory
 Important knowledge that persists permanently. Only update when you have something worth keeping forever.
 Use these sections to organize:
 
-### 사용자 & 멤버
-예시:
-- 회장님: 한국어 선호, 코드 품질 중시, 매주 월요일 주간보고
-- @김개발: 백엔드 전문, TypeScript 주력
+### Users & Members
+Example:
+- ${humanTitle}: prefers Korean, values code quality, weekly Monday reports
+- @dev-member: backend specialist, TypeScript focus
 
-### 프로젝트 & 구조
-예시:
+### Projects & Structure
+Example:
 - mococo-api: Express + TypeScript, repos/mococo-api
-- 배포: main → staging 자동, production 수동
+- Deploy: main → staging auto, production manual
 
-### 정책 & 규칙
-예시:
-- PR 머지는 회장님만 가능
-- 핫픽스는 autonomous 결정 가능, 기능 추가는 propose
+### Policies & Rules
+Example:
+- PR merge is ${humanTitle}-only
+- Hotfixes can be autonomous, feature additions need proposal
 
-### 팀 역량
-예시:
-- Backend팀: API 설계, DB 마이그레이션, 성능 최적화
-- Frontend팀: React, 배포 파이프라인, UI/UX
+### Team Capabilities
+Example:
+- Backend team: API design, DB migrations, performance optimization
+- Frontend team: React, deploy pipelines, UI/UX
 
 ${longTerm ? `\n${longTerm}\n` : '\n(empty)\n'}
 ## Short-term Memory
 Working context for current tasks. Update every response.
 Use these sections to organize:
 
-### 진행중 작업
-(현재 태스크, 담당자, 블로커 — 반드시 #ch:숫자ID 포함)
-예시:
-- FE 배포 스크립트 작성 중 #ch:${chId}
-- 팀원A에게 API 연동 위임, 결과 대기 #ch:${chId}
+### In Progress
+(current tasks, assignees, blockers — must include #ch:numericID)
+Example:
+- Writing FE deploy script #ch:${chId}
+- Delegated API integration to member A, awaiting result #ch:${chId}
 
-### 대기 항목
-(미완료 작업 — 반드시 #ch:숫자ID 포함. 태그: [BLOCKED], [SCHEDULED:YYYY-MM-DD], [READY])
-예시:
-- DB 마이그레이션 실행 #ch:1234567890123456
-- Redis 설정 [BLOCKED] — 팀원A 완료 대기 #ch:1234567890123456
-- 주간보고 작성 [SCHEDULED:2026-02-17] #ch:9876543210123456
+### Waiting
+(incomplete tasks — must include #ch:numericID. Tags: [BLOCKED], [SCHEDULED:YYYY-MM-DD], [READY])
+Example:
+- DB migration execution #ch:1234567890123456
+- Redis setup [BLOCKED] — waiting for member A #ch:1234567890123456
+- Weekly report [SCHEDULED:2026-02-17] #ch:9876543210123456
 
-### 캐시된 외부 데이터
-(API 조회 결과 + 조회 시각. 24시간 이상 경과 시 재조회 필요.)
-예시:
-- [2/12 10:30] 캘린더: 오늘 일정 3건 (팀미팅 14:00, 코드리뷰 16:00)
-- [2/12 09:00] GitHub PR: #142 리뷰 대기, #140 머지 완료
+### Cached External Data
+(API query results + query time. Re-query if older than 24 hours.)
+Example:
+- [2/12 10:30] Calendar: 3 events today (team meeting 14:00, code review 16:00)
+- [2/12 09:00] GitHub PR: #142 review pending, #140 merged
 
-⚠️ #ch: 뒤에는 반드시 실제 Discord 채널 ID(숫자)를 적어라. 현재 채널 ID: ${chId}
+⚠️ After #ch: you must write the actual Discord channel ID (numeric). Current channel ID: ${chId}
 ${shortTerm ? `\n${shortTerm}\n` : '\n(empty)\n'}`;
 }
 
-function buildDiscordCommandsSection(team: TeamConfig): string {
+function buildDiscordCommandsSection(team: TeamConfig, humanTitle: string, leaderName: string): string {
   const leaderDecisionLog = `
-**Decision Log (자율 결정 기록 — 리더 전용):**
-자율적으로 결정을 내릴 때 반드시 다음 태그를 출력에 포함:
-\`[decision:level reason="설명" action="조치 내용"]\`
+**Decision Log (autonomous decisions — leader only):**
+When making autonomous decisions, always include the following tag in your output:
+\`[decision:level reason="description" action="action taken"]\`
 
 Levels:
-- \`autonomous\` — 루틴 작업 (버그 수정, 리팩토링, 작업 재분배). 실행 후 기록만.
-- \`inform\` — 기존 범위 내 개선. 실행 후 보고.
-- \`propose\` — 새 기능, 아키텍처 변경, 새 도구 도입. 회장님 승인 대기.
-- \`escalate\` — 보안, 장애, 긴급. 즉시 회장님 태그.
+- \`autonomous\` — Routine tasks (bug fixes, refactoring, work redistribution). Execute and log.
+- \`inform\` — Improvements within existing scope. Execute and report.
+- \`propose\` — New features, architecture changes, new tools. Await ${humanTitle} approval.
+- \`escalate\` — Security, outages, urgent. Tag ${humanTitle} immediately.
 
-예: \`[decision:autonomous reason="중복 코드 발견" action="Backend팀에게 리팩토링 지시"]\`
-예: \`[decision:propose reason="새 인증 시스템 필요" action="회장님 승인 대기"]\`
+Example: \`[decision:autonomous reason="duplicate code found" action="assigned refactoring to Backend team"]\`
+Example: \`[decision:propose reason="new auth system needed" action="awaiting ${humanTitle} approval"]\`
 `;
 
   const memberImprovementNote = `
-**개선사항 발견 시 (비리더 팀 전용):**
-작업 중 버그, 보안 취약점, 성능 이슈, 리팩토링 필요 코드를 발견하면 대장코코에게 보고하라.
-output 마지막에 대장코코를 태그하고 발견 내용을 간단히 기술:
-예: \`<@대장코코ID> [발견] medium: utils.ts에 중복 코드, 리팩토링 필요\`
-이렇게 하면 시스템이 자동으로 대장코코를 invoke하여 판단한다.
+**When discovering improvements (non-leader teams only):**
+If you find bugs, security vulnerabilities, performance issues, or code needing refactoring, report to ${leaderName}.
+Tag ${leaderName} at the end of your output with a brief description:
+Example: \`<@leaderID> [found] medium: duplicate code in utils.ts, needs refactoring\`
+The system will automatically invoke ${leaderName} for evaluation.
 `;
 
   return `## Discord Commands
@@ -307,16 +307,16 @@ Syntax: \`[discord:action key=value key="quoted value"]\`
 - \`[discord:delete-role name=Developer]\`
 - \`[discord:assign-role role=Developer user=123456789]\` — assign role to user
 - \`[discord:remove-role role=Developer user=123456789]\` — remove role from user
-- \`[discord:list-roles]\` — 서버 역할 목록 조회 (이름, 멤버 수)
-- \`[discord:list-channels]\` — 서버 채널 목록 조회 (카테고리별 그룹핑)
+- \`[discord:list-roles]\` — list server roles (name, member count)
+- \`[discord:list-channels]\` — list server channels (grouped by category)
 
 **Permissions (channel/category):**
 - \`[discord:set-permission channel=my-channel role=Developer allow="ViewChannel,SendMessages"]\`
 - \`[discord:set-permission channel=my-channel role=Developer deny="SendMessages"]\` — read-only
 - \`[discord:set-permission category=Projects user=123456789 allow="ViewChannel"]\`
-- \`[discord:set-permission channel=my-channel role=Developer allow="ViewChannel" deny="SendMessages"]\` — allow+deny 동시 가능
-- \`[discord:remove-permission channel=my-channel role=Developer]\` — 해당 대상의 권한 덮어쓰기 전부 제거
-사용 가능한 권한: ViewChannel, SendMessages, ReadMessageHistory, ManageMessages, ManageChannels, ManageRoles, EmbedLinks, AttachFiles, AddReactions, Connect, Speak, MentionEveryone, CreatePublicThreads, CreatePrivateThreads, UseExternalEmojis
+- \`[discord:set-permission channel=my-channel role=Developer allow="ViewChannel" deny="SendMessages"]\` — allow+deny simultaneously
+- \`[discord:remove-permission channel=my-channel role=Developer]\` — remove all permission overrides for that target
+Available permissions: ViewChannel, SendMessages, ReadMessageHistory, ManageMessages, ManageChannels, ManageRoles, EmbedLinks, AttachFiles, AddReactions, Connect, Speak, MentionEveryone, CreatePublicThreads, CreatePrivateThreads, UseExternalEmojis
 
 **Short-term Memory (REQUIRED every response):**
 Update your short-term memory at the end of every response. Include the full replacement content:
@@ -328,7 +328,7 @@ Update your short-term memory at the end of every response. Include the full rep
 This overwrites your short-term memory completely. Keep it lean and up-to-date.
 What to track: ongoing tasks, current blockers, temp context needed for next invocation.
 What NOT to track: conversation text already in history, stable facts (promote those to long-term).
-**⚠️ 미완료 작업은 반드시 "### 대기 항목" 섹션에 #ch:channelId와 함께 기록하라.** 예: \`- API 연동 마무리 #ch:123456789\`
+**⚠️ Incomplete tasks MUST be recorded in the "### Waiting" section with #ch:channelId.** Example: \`- Finish API integration #ch:123456789\`
 
 **Long-term Memory (only when needed):**
 When you learn something worth keeping permanently, also output:
@@ -373,8 +373,16 @@ export async function buildTeamPrompt(
   }
   const template = fs.readFileSync(templatePath, 'utf-8');
   const conversationText = formatConversation(invocation.conversation);
-  const sharedRules = readCached(path.resolve(ws, 'prompts/shared-rules.md'));
+  const rawSharedRules = readCached(path.resolve(ws, 'prompts/shared-rules.md'));
   const memberList = readCached(path.resolve(ws, '.mococo/members.md'));
+
+  // Resolve placeholders in shared rules
+  const humanTitle = config.humanTitle ?? 'Boss';
+  const leaderTeam = Object.values(config.teams).find(t => t.isLeader);
+  const leaderName = leaderTeam?.name ?? 'Leader';
+  const sharedRules = rawSharedRules
+    .replace(/\{\{humanTitle\}\}/g, humanTitle)
+    .replace(/\{\{leaderName\}\}/g, leaderName);
 
   // 2. Build dynamic context
   const teamDirectory = buildTeamDirectory(config, team.id);
@@ -387,8 +395,8 @@ export async function buildTeamPrompt(
   const currentTime = new Date().toISOString().slice(0, 16).replace('T', ' ');
 
   // 4. Build prompt sections
-  const memorySection = buildMemorySection(longTerm, shortTerm, chId);
-  const discordCommands = buildDiscordCommandsSection(team);
+  const memorySection = buildMemorySection(longTerm, shortTerm, chId, humanTitle);
+  const discordCommands = buildDiscordCommandsSection(team, humanTitle, leaderName);
 
   // 5. Build inbox/memory instruction (leader vs member)
   const inboxInstruction = team.isLeader
@@ -398,7 +406,7 @@ ${inbox ? `\n${inbox}\n` : '(no new messages)\n'}
     : `**You MUST update your short-term memory at the end of every response** using the memory command (see Discord Commands below). Review your current memory, incorporate new information, and remove anything outdated.`;
 
   // 6. Build mention info
-  const humanMention = config.humanDiscordId ? `- Human (회장님): <@${config.humanDiscordId}>` : '';
+  const humanMention = config.humanDiscordId ? `- Human (${humanTitle}): <@${config.humanDiscordId}>` : '';
   const triggerMention = invocation.message.discordId && invocation.message.discordId !== config.humanDiscordId
     ? `\n- ${invocation.message.teamName}: <@${invocation.message.discordId}>`
     : '';
@@ -419,19 +427,19 @@ ${team.teamRules?.length ? `\n### Team Rules\n${team.teamRules.map(r => `- ${r}`
   return `${template}
 ${sharedRules ? `\n${sharedRules}\n` : ''}
 ## Current Context
-현재 채널: ${chId}
-현재 시각: ${currentTime}
+Current channel: ${chId}
+Current time: ${currentTime}
 
 ${memorySection}
-## Recent Activity (자동 생성 — 수정 불필요)
-최근 활동 요약. 이전 호출에서 무엇을 했는지 파악하여 맥락을 이어가라.
+## Recent Activity (auto-generated — do not edit)
+Summary of recent activity. Review what was done in previous invocations to maintain context.
 ${recentEpisodes || '(no recent activity)'}
 
 ${inboxInstruction}
-**⚠️ CRITICAL: 외부 도구 호출 전 반드시 메모리를 먼저 확인하라.**
-- Short-term/Long-term Memory에 이미 있는 데이터는 절대 다시 API 호출하지 마라.
-- 예: 일주일치 일정을 이미 조회해서 메모리에 있으면, 오늘 일정을 물어봤을 때 메모리에서 추출하라. 같은 데이터를 또 API로 가져오지 마라.
-- 외부 도구(API, MCP 서버)는 메모리에 관련 데이터가 전혀 없거나, 데이터가 오래되었거나(24시간+), 사용자가 명시적으로 "새로 조회해줘"라고 요청한 경우에만 호출하라.
+**⚠️ CRITICAL: Always check memory before calling external tools.**
+- Never re-call APIs for data already in Short-term/Long-term Memory.
+- Example: If a week's schedule is already in memory, extract today's events from memory. Don't fetch the same data again.
+- Only call external tools (APIs, MCP servers) when: no related data in memory, data is stale (24h+), or user explicitly requests a fresh query.
 
 ## Server Members
 ${memberList || '(no member data)'}
@@ -446,10 +454,10 @@ ${conversationText}
 \`\`\`
 
 ## Discord Mentions
-**보내기: 말을 전달하려는 대상은 반드시 전부 태그한다. 예외 없음.**
-- 대상이 1명이면 \`<@ID>\`로 시작
-- 대상이 여러 명이면 전부 나열: \`<@ID1> <@ID2> <@ID3>\`로 시작
-- 답변, 보고, 위임, 질문 — 모든 경우에 태그
+**Sending: Always tag everyone you're addressing. No exceptions.**
+- For 1 recipient: start with \`<@ID>\`
+- For multiple: list all: \`<@ID1> <@ID2> <@ID3>\`
+- Replies, reports, delegations, questions — always tag
 
 ${humanMention}${triggerMention}
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -42,6 +42,7 @@ export interface TeamsConfig {
   conversationWindow: number;
   workspacePath: string;
   humanDiscordId?: string;
+  humanTitle?: string;          // title for the human (e.g. "Boss"), default "Boss"
 }
 
 export interface ConversationMessage {


### PR DESCRIPTION
## Summary
- `humanTitle` 파라미터화: `회장님` 하드코딩 → `teams.json`의 `humanTitle` 필드 참조
- `{{leaderName}}` 플레이스홀더: `대장코코` 직접 참조 → 런타임 치환
- CLI 영어 기본화: `add.ts`, `edit.ts`, `init.ts` 전체 한국어 문자열 → 영어
- `prompt-builder.ts` 시스템 프롬프트 영어화: 메모리 섹션, Discord 커맨드 가이드, 멘션 규칙
- `.env.example` 생성: 새 워크스페이스 설정 가이드
- `defaults/shared-rules.md` 템플릿: `init` 시 자동 복사
- git email prefix `mococo-` 제거: 신규 에이전트 기본값 중립화

## Impact
- 기존 배포에 영향 없음 (teams.json의 기존 humanTitle="Boss" 유지)
- 신규 포크 사용자가 자체 브랜딩으로 커스텀 가능

## Test plan
- [x] TypeScript 타입체크 통과 (`tsc --noEmit`)
- [ ] `mococo start` 정상 기동 확인
- [ ] `mococo add` 위자드 영어 출력 확인
- [ ] 플레이스홀더 치환 동작 검증 (shared-rules 내 humanTitle/leaderName)

🤖 Generated with [Claude Code](https://claude.com/claude-code)