### PR TITLE
feat. CLI i18n + README bilingual docs

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -17,5 +17,10 @@ HOOK_PORT=9876
 # BACKEND_DISCORD_TOKEN=your-backend-bot-token
 # FRONTEND_DISCORD_TOKEN=your-frontend-bot-token
 
+# GitHub token for push/PR operations
+# GITHUB_TOKEN=ghp_xxxxxxxxxxxxxxxxxxxx
+# or
+# GH_TOKEN=ghp_xxxxxxxxxxxxxxxxxxxx
+
 # MCP server credentials (if using MCP integrations)
 # GOOGLE_OAUTH_CREDENTIALS=/path/to/oauth-credentials.json

--- a/README.ko.md
+++ b/README.ko.md
@@ -1,5 +1,7 @@
 # claude-mococo
 
+[English](README.md)
+
 **Discord 위의 AI 어시스턴트.** 각 어시스턴트는 AI 엔진(Claude, Codex, Gemini)으로 구동되는 실제 Discord 봇입니다. 고유한 GitHub 계정, 성격, 권한을 가집니다. 하나부터 시작해서 필요할 때 더 추가하세요.
 
 ```
@@ -19,7 +21,7 @@
 npm install -g claude-mococo
 ```
 
-AI 엔진도 최소 하나 필요합니다:
+AI 엔진 CLI도 최소 하나 필요합니다:
 
 ```bash
 claude --version                  # Claude CLI (추천)
@@ -39,15 +41,24 @@ npm install -g @google/gemini-cli # Gemini CLI (선택)
    - Permissions: `Send Messages`, `Read Message History`, `Embed Links`, `Attach Files`
    - URL 복사 → 브라우저에서 열기 → 서버에 추가
 
+> 어시스턴트마다 별도의 Discord 봇이 필요합니다. 위 과정을 반복하세요.
+
 ### 3. 워크스페이스 생성 및 어시스턴트 추가
 
 ```bash
 mkdir my-team && cd my-team
-mococo init                   # 워크스페이스 생성 (Discord 채널 ID 입력)
-mococo add                    # 대화형 마법사 — 이름, 엔진, 토큰 등 입력
+mococo init                   # 워크스페이스 생성
+mococo add                    # 대화형 마법사
 ```
 
-커밋에는 어시스턴트 이름이 작성자로 표시됩니다 (`teams.json`의 `git.name`으로 설정). 어시스턴트가 푸시나 PR을 생성해야 하면 `mococo add` 시 GitHub PAT를 입력하세요.
+`init`과 `add` 모두 언어 플래그를 지원합니다:
+
+```bash
+mococo init --lang ko         # 한국어 프롬프트
+mococo add --lang en          # 영어 프롬프트 (기본값)
+```
+
+`--lang` 생략 시 시작할 때 물어봅니다: `Use Korean? (한국어로 진행할까요?) [y/N]`
 
 ### 4. 저장소 연결 및 시작
 
@@ -66,34 +77,506 @@ Discord 채널에서 봇에게 말을 걸면 됩니다.
 |--------|------|
 | `mococo init` | 현재 디렉토리에 워크스페이스 생성 |
 | `mococo add` | 어시스턴트 추가 (대화형 마법사) |
+| `mococo edit <id>` | 어시스턴트 설정 편집 |
 | `mococo start` | 모든 어시스턴트 시작 |
+| `mococo dev` | 개발 모드 (트리거 시 자동 리빌드) |
+| `mococo restart` | 리빌드+재시작 트리거 (`dev`와 함께 사용) |
 | `mococo list` | 설정된 어시스턴트 목록 |
 | `mococo remove <id>` | 어시스턴트 제거 |
 
+**공통 옵션:** `--lang <en|ko>` — `init`, `add`, `edit`의 CLI 언어 설정.
+
 ---
 
-## 어시스턴트 추가하기
+## 상세 명령어 레퍼런스
+
+### `mococo init`
+
+새 워크스페이스를 생성하거나 기존 워크스페이스를 업데이트합니다.
 
 ```bash
-mococo add        # 새 어시스턴트마다 반복
+mkdir my-team && cd my-team
+mococo init
 ```
 
-각 어시스턴트는:
-- 고유한 Discord 봇 (채팅에서 별도 신원)
-- 고유한 git 작성자 이름 (커밋 메시지에 표시)
-- `teams.json`의 별도 항목 (엔진, 성격, 권한)
+**실행 화면:**
 
-이렇게 팀을 구성할 수 있습니다:
+```
+Use Korean? (한국어로 진행할까요?) [y/N]: y
 
-| 어시스턴트 | 엔진 | 역할 |
-|-----------|------|------|
-| Leader | Claude | 다른 어시스턴트에게 작업 위임 |
-| Planner | Codex | 계획 및 스펙 작성 |
-| Coder | Claude | 코드 작성 |
-| Reviewer | Claude | 리뷰 및 PR 생성 |
-| Designer | Gemini | UI/UX 가이드 |
+워크스페이스를 초기화합니다...
 
-혼자 하나만 써도 됩니다. 선택은 자유입니다.
+Discord 작업 채널 ID (전체 채널이면 비워두세요): 1234567890123456
+Discord 사용자 ID (이름 우클릭 → 사용자 ID 복사): 9876543210987654
+
+워크스페이스가 생성되었습니다:
+  teams.json   — 어시스턴트 설정
+  .env         — 토큰 및 설정
+  prompts/     — 성격 파일
+  repos/       — 연결된 저장소
+  hooks/       — Claude Code 훅
+
+다음: `mococo add`를 실행하여 첫 어시스턴트를 추가하세요.
+```
+
+**생성되는 파일:**
+
+| 파일/디렉토리 | 용도 |
+|---------------|------|
+| `teams.json` | 메인 설정 — 모든 어시스턴트 정의 |
+| `.env` | 토큰 및 환경 변수 |
+| `.gitignore` | `.env`, `.mococo/`, `repos/*` 제외 |
+| `prompts/` | 각 어시스턴트의 성격 파일 |
+| `prompts/shared-rules.md` | 모든 어시스턴트가 공유하는 공통 규칙 |
+| `repos/` | 실제 저장소로의 심볼릭 링크 |
+| `hooks/` | Claude Code git 훅 |
+| `.mococo/` | 내부 상태 디렉토리 |
+
+**재초기화:** `teams.json`이 이미 존재하면, `mococo init`은 모든 어시스턴트를 보존하고 전역 설정(채널 ID, 사용자 ID, 훅)만 업데이트합니다.
+
+---
+
+### `mococo add`
+
+새 AI 어시스턴트를 추가하는 대화형 마법사입니다. 모든 설정 옵션을 단계별로 안내합니다.
+
+```bash
+mococo add
+# 또는 한국어로:
+mococo add --lang ko
+```
+
+**전체 마법사 진행 화면:**
+
+```
+한국어로 진행할까요? [y/N]: y
+
+새 에이전트 추가
+
+── 신원 ──
+어시스턴트 ID (소문자, 예: hr): backend
+표시 이름 (예: Backend) (Backend): 백엔드 개발자
+리더입니까 (모든 메시지에 응답)? [y/N]: N
+
+── 캐릭터 ──
+MBTI:
+  > 1. ENTJ — 전략가, 결단력, 큰 그림을 보는 리더
+    2. ISTJ — 규칙 준수, 체계적, 정확성 중심
+    3. ENFJ — 사람 중심, 공감 능력, 팀 조화
+    4. INTP — 분석적, 논리적, 깊이 파는 탐구자
+    5. 직접 입력
+선택 (1): 2
+
+말투:
+  > 1. 모두에게 존댓말
+    2. 사람에게 존댓말 + 동료에게 반말
+    3. 직접 입력
+선택 (1): 2
+
+성격 특성 (행동 예시 포함, 쉼표 구분):
+  예: "체계적 — 모든 요구사항을 구조화, 신중함 — 불확실하면 검증"
+  특성: 꼼꼼함 — 엣지 케이스를 잡아냄, 효율적 — 최소 코드로 최대 효과
+
+습관 (쉼표 구분):
+  예: "결론→근거→다음 단계 순서로 보고"
+  습관: 항상 테스트부터 작성, API 변경 시 즉시 문서화
+
+── 역할 ──
+핵심 역할 (1-2문장): API 설계, 데이터베이스, 서버 로직을 담당하는 백엔드 개발자.
+
+담당 범위 (쉼표 구분):
+  범위: API 개발, 데이터베이스 설계, 서버 아키텍처
+
+담당 아님 (쉼표 구분):
+  담당 아님: UI/UX, 프론트엔드 스타일링
+
+독립 결정 권한: API 구조, DB 스키마, 코드 스타일
+승인 필요 사항: 대규모 아키텍처 변경, 새 프레임워크 도입
+
+전문 분야 (쉼표 구분):
+  전문 분야: Python, FastAPI, PostgreSQL, Docker
+
+추가 규칙 (쉼표 구분):
+  규칙: 입력값 항상 검증, 내부 에러를 클라이언트에 노출 금지
+
+에이전트 팀 모드 활성화 (병렬 서브 에이전트)? [y/N]: N
+
+── 엔진 ──
+Engine:
+  > 1. claude
+    2. codex
+    3. gemini
+선택 (1): 1
+모델 (sonnet): opus
+호출당 최대 예산 ($) (10): 10
+
+── 토큰 ──
+Discord 봇 토큰: MTIz...your-token-here
+
+── 채널 ──
+봇이 응답할 채널 ID (쉼표 구분, 비우면 전체 채널):
+  채널:
+
+── 권한 ──
+권한 프리셋:
+    1. 전체 — 푸시, PR 생성 가능
+  > 2. 개발자 — 파일 수정 가능, 푸시 불가
+    3. 읽기 전용 — 수정 불가, 푸시 불가
+선택 (2): 1
+
+── Git 신원 ──
+Git 작성자 이름 (백엔드 개발자 (mococo)): 백엔드 개발자
+Git 작성자 이메일 (backend@users.noreply.github.com):
+
+"백엔드 개발자" (backend) 추가 완료.
+  설정:    teams.json
+  프롬프트:  prompts/backend.md  (편집 가능)
+  토큰:    .env
+
+`mococo start`로 실행하세요.
+```
+
+**생성되는 것:**
+- `teams.json`에 모든 설정이 포함된 항목
+- `.env`에 `{ID}_DISCORD_TOKEN=...` 추가
+- `prompts/{id}.md` — 자동 생성된 성격 파일 (자유롭게 편집 가능)
+
+---
+
+### `mococo edit <id>`
+
+기존 어시스턴트의 설정을 편집합니다.
+
+```bash
+mococo edit backend
+```
+
+**메뉴:**
+
+```
+어시스턴트 편집 중 "백엔드 개발자" (backend)
+
+편집할 항목:
+  > 1. name        — 표시 이름
+    2. character   — MBTI, 말투, 성격, 습관
+    3. role        — 범위, 권한, 전문성
+    4. engine      — 엔진 및 모델
+    5. budget      — 최대 예산
+    6. channels    — 채널 제한
+    7. permissions — 권한 프리셋
+    8. git         — Git 작성자 정보
+    9. all         — 전부 편집
+선택 (8):
+```
+
+- **character** 또는 **role** 편집 시 성격 파일(`prompts/{id}.md`) 재생성 여부를 물어봅니다
+- 개별 섹션을 편집하거나 `all`을 선택해 전체를 다시 설정할 수 있습니다
+
+---
+
+### `mococo list` / `mococo ls`
+
+설정된 모든 어시스턴트를 테이블로 표시합니다.
+
+```bash
+mococo list
+```
+
+**출력 예시:**
+
+```
+  ID               Name             Engine     Model              Leader
+  ──────────────── ──────────────── ────────── ────────────────── ──────
+  leader           팀 리더          claude     sonnet             yes
+  backend          백엔드 개발자     claude     opus
+  designer         디자이너          gemini     gemini-2.5-pro
+```
+
+---
+
+### `mococo remove <id>` / `mococo rm <id>`
+
+어시스턴트를 제거하고 관련 파일을 정리합니다.
+
+```bash
+mococo remove backend
+```
+
+**제거되는 것:**
+- `teams.json`에서 해당 항목
+- `prompts/{id}.md` — 성격 파일
+- `.env`에서 `{ID}_*` 토큰 라인
+
+---
+
+### `mococo start`
+
+설정된 모든 어시스턴트를 시작합니다.
+
+```bash
+mococo start
+```
+
+**동작 과정:**
+1. 워크스페이스에서 `.env` 로드
+2. `teams.json` 설정 로드
+3. 각 어시스턴트의 Discord 토큰 존재 여부 검증
+4. HTTP 훅 수신 서버 시작 (기본 포트: 9876)
+5. 유효한 토큰이 있는 각 어시스턴트의 Discord 봇 생성
+
+**출력:**
+
+```
+Starting 3 assistant(s)...
+mococo running — 3/3 assistants online (engines: claude, gemini)
+```
+
+**요구 사항:**
+- mococo 워크스페이스(`teams.json`이 있는 디렉토리)에서 실행
+- 각 어시스턴트에 `.env`의 `{ID}_DISCORD_TOKEN` 필요
+
+---
+
+### `mococo dev`
+
+개발 모드로 시작합니다. 재시작 트리거를 감시하며, 트리거 시 TypeScript를 리빌드하고 봇을 재시작합니다.
+
+```bash
+mococo dev
+```
+
+`nodemon`을 사용하여 변경사항을 감시합니다.
+
+---
+
+### `mococo restart`
+
+`dev` 모드 실행 중 리빌드 및 재시작을 트리거합니다.
+
+```bash
+# `mococo dev` 실행 중인 다른 터미널에서:
+mococo restart
+```
+
+---
+
+## 설정 레퍼런스
+
+### teams.json
+
+메인 설정 파일입니다. `mococo init`으로 생성되고, `mococo add`/`edit`으로 업데이트됩니다.
+
+```jsonc
+{
+  "teams": {
+    "leader": {
+      "name": "팀 리더",
+      "color": "#5865F2",
+      "avatar": "crown",
+      "engine": "claude",
+      "model": "sonnet",
+      "maxBudget": 10,
+      "prompt": "prompts/leader.md",
+      "isLeader": true,
+      "useTeams": false,
+      "channels": [],
+      "git": {
+        "name": "팀 리더",
+        "email": "leader@users.noreply.github.com"
+      },
+      "permissions": {
+        "allow": ["git push", "gh pr create"],
+        "deny": ["gh pr merge"]
+      },
+      "mcpServers": {}
+    }
+  },
+  "globalDeny": ["gh pr merge", "git push --force main", "git push --force master"],
+  "conversationWindow": 30,
+  "humanDiscordId": "123456789012345678",
+  "humanTitle": "사장님"
+}
+```
+
+**어시스턴트별 필드:**
+
+| 필드 | 타입 | 설명 |
+|------|------|------|
+| `name` | string | Discord에서의 표시 이름 |
+| `color` | hex string | Discord 임베드 색상 |
+| `avatar` | string | 아바타 키 (`robot`, `crown`, `brain`, `gear`, `palette`, `shield`, `eye`, `test`, `book`) |
+| `engine` | string | `"claude"`, `"codex"`, 또는 `"gemini"` |
+| `model` | string | 모델명 (예: `"sonnet"`, `"opus"`, `"o3"`, `"gemini-2.5-pro"`) |
+| `maxBudget` | number | 호출당 최대 비용 — 달러 (Claude만 해당) |
+| `prompt` | string | 성격/지시사항 파일 경로 |
+| `isLeader` | boolean | `true`면 모든 메시지에 응답 (@멘션 불필요) |
+| `useTeams` | boolean | 에이전트 팀 모드 활성화 (병렬 서브 에이전트) |
+| `teamRules` | string[] | 서브 에이전트 행동 규칙 |
+| `channels` | string[] | 응답할 채널 ID (비어 있으면 전체) |
+| `discordUserId` | string | 첫 봇 로그인 시 자동 설정 |
+| `git.name` | string | Git 커밋 작성자 이름 |
+| `git.email` | string | Git 커밋 작성자 이메일 |
+| `mcpServers` | object | MCP 서버 설정 (환경 변수는 `$VAR` 문법) |
+| `permissions.allow` | string[] | 허용된 쉘 명령어 |
+| `permissions.deny` | string[] | 차단된 쉘 명령어 |
+
+**전역 필드:**
+
+| 필드 | 타입 | 설명 |
+|------|------|------|
+| `globalDeny` | string[] | 모든 어시스턴트에게 차단되는 명령어 |
+| `conversationWindow` | number | 컨텍스트에 포함할 최근 메시지 수 |
+| `humanDiscordId` | string | Discord 사용자 ID |
+| `humanTitle` | string | 어시스턴트가 사용자를 부르는 호칭 (예: "사장님", "Boss") |
+
+### .env
+
+환경 변수 파일입니다. `mococo init`으로 생성됩니다.
+
+```bash
+# 필수
+WORK_CHANNEL_ID=1234567890123456   # 비워두면 전체 채널
+HOOK_PORT=9876                      # HTTP 웹훅 수신 포트
+
+# 선택
+MEMBER_TRACKING_CHANNEL_ID=         # 멤버 이벤트 채널
+DECISION_LOG_CHANNEL_ID=            # 리더 결정 로그 채널
+GITHUB_TOKEN=ghp_xxxxx             # 푸시/PR용 GitHub PAT
+
+# 어시스턴트별 하나씩 (`mococo add` 시 자동 추가)
+LEADER_DISCORD_TOKEN=your-token-here
+BACKEND_DISCORD_TOKEN=your-token-here
+```
+
+### prompts/{id}.md
+
+자동 생성되는 성격 파일입니다. 자유롭게 편집할 수 있습니다 — 이 파일에서 각 어시스턴트의 캐릭터, 역할, 규칙이 정의됩니다.
+
+**생성 구조:**
+
+```markdown
+# 어시스턴트 이름
+
+You are **어시스턴트 이름**, an AI assistant on Discord.
+When addressing the human, always call them **사장님**.
+
+## Character
+- **MBTI:** ISTJ — 규칙 준수, 체계적, 정확성 중심
+- **Speech style:**
+  - To the human: strictly formal and respectful
+  - To other agents: casual and direct
+- **Personality:**
+  - 꼼꼼함 — 엣지 케이스를 잡아냄
+- **Habits:**
+  - 항상 테스트부터 작성
+
+## Role
+API 설계, 데이터베이스, 서버 로직을 담당하는 백엔드 개발자.
+
+**Scope:**
+- API 개발
+- 데이터베이스 설계
+
+**Not in scope:**
+- UI/UX
+
+**Decision authority:**
+- Independent: API 구조, DB 스키마
+- Needs approval: 대규모 아키텍처 변경
+
+## Expertise
+- Python
+- FastAPI
+
+## Rules
+- 입력값 항상 검증
+```
+
+### prompts/shared-rules.md
+
+모든 어시스턴트에 자동으로 포함되는 공통 규칙입니다. `mococo init` 시 `defaults/shared-rules.md`에서 복사됩니다.
+
+포함 내용:
+- 우선순위 체계 (규칙 > 역할 > 성격)
+- 명령 체계 (사람 > 리더 > 본인)
+- 절대 금지 사항 (머지 금지, 크레덴셜 노출 금지)
+- 태그 및 대화 관리
+- 메모리 및 행동 가이드라인
+- 신규 에이전트 환영 프로토콜
+
+`{{humanTitle}}`과 `{{leaderName}}` 플레이스홀더를 사용하며, 런타임에 실제 값으로 치환됩니다.
+
+---
+
+## 사용 시나리오
+
+### 시나리오 1: 단일 어시스턴트
+
+가장 간단한 구성 — 모든 것을 처리하는 봇 하나.
+
+```bash
+mkdir my-project && cd my-project
+mococo init
+mococo add
+# → ID: assistant, Engine: claude, Model: opus
+# → 권한: 전체
+
+ln -s /경로/my-app repos/my-app
+mococo start
+```
+
+Discord에서 `@assistant`를 멘션:
+
+```
+나: @assistant 회원가입 폼에 입력값 검증 추가해줘
+봇: 이메일 형식, 비밀번호 강도, 필수 필드 검증을 추가하겠습니다.
+    → 변경 → 커밋 → 푸시 → PR 생성
+```
+
+### 시나리오 2: 멀티 어시스턴트 팀
+
+리더가 전문가에게 작업을 위임하는 팀 구성.
+
+```bash
+mkdir my-team && cd my-team
+mococo init
+
+# 리더 추가 (모든 메시지에 응답, 작업 위임)
+mococo add
+# → ID: leader, isLeader: yes, Engine: claude, Model: sonnet
+# → 권한: 읽기 전용 (리더는 코딩하지 않고 위임만)
+
+# 백엔드 개발자 추가
+mococo add
+# → ID: backend, Engine: claude, Model: opus
+# → 권한: 전체
+
+# 프론트엔드 개발자 추가
+mococo add
+# → ID: frontend, Engine: claude, Model: opus
+# → 권한: 전체
+
+# 저장소 연결
+ln -s /경로/api repos/api
+ln -s /경로/web repos/web
+mococo start
+```
+
+Discord 채널에서 말하면 됩니다 (@멘션 불필요 — 리더가 자동으로 받음):
+
+```
+나: 유저 프로필 페이지 만들어줘. API 엔드포인트도 필요해.
+
+리더: 조율하겠습니다.
+      @backend GET /api/users/:id 엔드포인트 만들어라
+      @frontend 프로필 페이지 컴포넌트 만들어라
+
+backend: API 엔드포인트 작업합니다...
+         → 코드 커밋 → 푸시 → PR 생성
+
+frontend: 프로필 컴포넌트 작업합니다...
+          → 코드 커밋 → 푸시 → PR 생성
+```
 
 ---
 
@@ -103,36 +586,24 @@ mococo add        # 새 어시스턴트마다 반복
 - 특정 봇을 `@멘션` → 해당 어시스턴트가 응답
 - 멘션 없음 → `"isLeader": true`인 어시스턴트가 응답
 
-**어시스턴트가 다른 어시스턴트를 멘션하면** (예: `@Reviewer 확인 부탁`) → 자동으로 호출됩니다.
+**크로스 어시스턴트 호출:**
+어시스턴트가 다른 어시스턴트를 멘션하면 (예: `@Backend 확인 부탁`) → 자동으로 호출됩니다.
 
-**권한**은 `teams.json`에서 어시스턴트별로 제어합니다:
+**엔진:**
+- `"claude"` — 풀 에이전트 (파일 수정, git, 쉘 명령어)
+- `"codex"` — 텍스트 전용 어드바이저
+- `"gemini"` — 텍스트 전용 어드바이저
+
+**권한**은 어시스턴트별로 제어합니다:
 
 ```jsonc
 "permissions": {
-  "allow": ["git push", "gh pr create"],
-  "deny": ["gh pr merge"]
+  "allow": ["git push", "gh pr create"],   // 명시적 허용
+  "deny": ["gh pr merge"]                   // 명시적 차단
 }
 ```
 
-**엔진:** `"claude"`는 풀 에이전트(파일, git, 명령어). `"codex"`와 `"gemini"`는 텍스트 전용 어드바이저.
-
----
-
-## 설정 레퍼런스
-
-### teams.json 필드
-
-| 필드 | 설명 |
-|------|------|
-| `engine` | `"claude"`, `"codex"`, 또는 `"gemini"` |
-| `model` | 모델명 (예: `"sonnet"`, `"opus"`, `"o3"`, `"gemini-2.5-pro"`) |
-| `maxBudget` | 호출당 최대 비용 (Claude만 해당) |
-| `prompt` | 성격/지시사항 파일 경로 |
-| `isLeader` | `true`면 모든 메시지에 응답 (@멘션 불필요) |
-| `git.name` / `git.email` | 커밋 작성자 정보 |
-| `permissions.allow` / `permissions.deny` | 허용/차단 쉘 명령어 |
-
-### Discord 명령어
+**Discord 명령어** (채팅에 입력):
 
 | 명령어 | 설명 |
 |--------|------|
@@ -142,14 +613,39 @@ mococo add        # 새 어시스턴트마다 반복
 
 ---
 
+## 워크스페이스 구조
+
+설정 완료 후 워크스페이스는 다음과 같습니다:
+
+```
+my-team/
+├── teams.json              # 어시스턴트 설정
+├── .env                    # 토큰 및 설정
+├── .gitignore              # .env, .mococo/, repos/* 제외
+├── prompts/
+│   ├── shared-rules.md     # 모든 어시스턴트 공통 규칙
+│   ├── leader.md           # 리더 성격
+│   ├── backend.md          # 백엔드 성격
+│   └── frontend.md         # 프론트엔드 성격
+├── repos/
+│   ├── .gitkeep
+│   ├── api -> /경로/api            # 심볼릭 링크
+│   └── web -> /경로/web            # 심볼릭 링크
+├── hooks/                  # Claude Code git 훅
+└── .mococo/                # 내부 상태
+```
+
+---
+
 ## 수동 설정 (CLI 없이)
 
 저장소를 직접 클론해서 설정할 수도 있습니다:
 
 ```bash
-git clone https://github.com/anthropics/claude-mococo.git
+git clone https://github.com/wodn5515/claude-mococo.git
 cd claude-mococo
 npm install
+npm run build
 ```
 
 `teams.json`을 직접 편집하고, `prompts/`에 프롬프트 파일을 만들고, `.env`에 토큰을 설정한 후 `npm start`로 실행합니다.
@@ -161,10 +657,13 @@ npm install
 | 문제 | 해결 |
 |------|------|
 | 봇이 응답 안 함 | Discord Developer Portal에서 **Message Content Intent** 활성화 |
-| "No team has a Discord token" | `.env`에 토큰 환경변수 추가 |
-| GitHub 푸시 불가 | `.env`의 GitHub PAT 확인 |
+| "No assistant has a Discord token" | `.env`에 토큰 추가 (`{ID}_DISCORD_TOKEN=...`) |
+| GitHub 푸시 불가 | `.env`에 유효한 PAT로 `GITHUB_TOKEN` 설정 |
 | 커밋 작성자 틀림 | `git.email`을 `USERNAME@users.noreply.github.com`으로 설정 |
-| "command not found: codex" | 설치하거나 engine을 `"claude"`로 변경 |
+| "command not found: codex" | 설치하거나 (`npm i -g @openai/codex`) engine을 `"claude"`로 변경 |
+| 봇이 잘못된 채널에서 응답 | `teams.json`의 `channels` 또는 `.env`의 `WORK_CHANNEL_ID` 설정 |
+
+---
 
 ## 라이선스
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 # claude-mococo
 
-**AI assistants on Discord.** Each assistant is a real Discord bot backed by an AI engine (Claude, Codex, Gemini). It has its own GitHub account, personality, and permissions. Start with one, add more when you need them.
+[한국어](README.ko.md)
+
+**AI assistants on Discord.** Each assistant is a real Discord bot backed by an AI engine (Claude, Codex, Gemini). It has its own GitHub identity, personality, and permissions. Start with one, add more when you need them.
 
 ```
 You: "Add a login page to my-app"
@@ -19,7 +21,7 @@ Assistant (bot): "On it. I'll create the auth routes and login form."
 npm install -g claude-mococo
 ```
 
-You also need at least one AI engine:
+You also need at least one AI engine CLI:
 
 ```bash
 claude --version                  # Claude CLI (recommended)
@@ -39,15 +41,24 @@ npm install -g @google/gemini-cli # Gemini CLI (optional)
    - Permissions: `Send Messages`, `Read Message History`, `Embed Links`, `Attach Files`
    - Copy the URL → open in browser → add to your server
 
+> Repeat this for each assistant you want to run (each needs its own Discord bot).
+
 ### 3. Initialize and add your assistant
 
 ```bash
 mkdir my-team && cd my-team
-mococo init                   # creates workspace (asks for Discord channel ID)
-mococo add                    # interactive wizard — asks for name, engine, tokens, etc.
+mococo init                   # creates workspace
+mococo add                    # interactive wizard
 ```
 
-Commits will show the assistant's name as the author (configured via `git.name` in `teams.json`). If you need assistants to push or create PRs, provide your GitHub PAT during `mococo add`.
+Both `init` and `add` support a language flag:
+
+```bash
+mococo init --lang ko         # Korean prompts
+mococo add --lang en          # English prompts (default)
+```
+
+If `--lang` is omitted, you'll be asked at the start: `Use Korean? (한국어로 진행할까요?) [y/N]`
 
 ### 4. Link your repos and start
 
@@ -66,73 +77,531 @@ Talk to your bot in the Discord channel. Done.
 |---------|-------------|
 | `mococo init` | Create a new workspace in the current directory |
 | `mococo add` | Add an assistant (interactive wizard) |
+| `mococo edit <id>` | Edit an assistant's settings |
 | `mococo start` | Start all assistants |
+| `mococo dev` | Start in dev mode (auto-rebuild on trigger) |
+| `mococo restart` | Trigger rebuild + restart (use with `dev`) |
 | `mococo list` | List configured assistants |
 | `mococo remove <id>` | Remove an assistant |
 
+**Global option:** `--lang <en|ko>` — set CLI language for `init`, `add`, and `edit`.
+
 ---
 
-## Adding More Assistants
+## Detailed Command Reference
+
+### `mococo init`
+
+Creates a new workspace or updates an existing one.
 
 ```bash
-mococo add        # repeat for each new assistant
+mkdir my-team && cd my-team
+mococo init
 ```
 
-Each one gets:
-- Its own Discord bot (separate identity in chat)
-- Its own git author name (visible in commit messages)
-- Its own entry in `teams.json` (engine, personality, permissions)
+**What you'll see:**
 
-You can build a full team this way:
+```
+Use Korean? (한국어로 진행할까요?) [y/N]: N
 
-| Assistant | Engine | Role |
-|-----------|--------|------|
-| Leader | Claude | Delegates work to other assistants |
-| Planner | Codex | Creates plans and specs |
-| Coder | Claude | Writes code |
-| Reviewer | Claude | Reviews and opens PRs |
-| Designer | Gemini | UI/UX guidance |
+Initializing workspace...
 
-Or just run a single assistant. It's up to you.
+Discord work channel ID (leave empty for all channels): 1234567890123456
+Your Discord user ID (right-click your name → Copy User ID): 9876543210987654
+
+Workspace created:
+  teams.json   — assistant configuration
+  .env         — tokens and settings
+  prompts/     — personality files
+  repos/       — linked repositories
+  hooks/       — Claude Code hooks
+
+Next: run `mococo add` to add your first assistant.
+```
+
+**Created files:**
+
+| File/Directory | Purpose |
+|----------------|---------|
+| `teams.json` | Main configuration — all assistant definitions |
+| `.env` | Tokens and environment variables |
+| `.gitignore` | Excludes `.env`, `.mococo/`, `repos/*` |
+| `prompts/` | Personality files for each assistant |
+| `prompts/shared-rules.md` | Common rules shared by all assistants |
+| `repos/` | Symlinks to your actual repositories |
+| `hooks/` | Claude Code git hooks |
+| `.mococo/` | Internal state directory |
+
+**Re-initialization:** If `teams.json` already exists, `mococo init` preserves all assistants and only updates global settings (channel ID, user ID, hooks).
+
+---
+
+### `mococo add`
+
+Interactive wizard to add a new AI assistant. Walks you through every configuration option.
+
+```bash
+mococo add
+# or with Korean prompts:
+mococo add --lang ko
+```
+
+**Full wizard walkthrough:**
+
+```
+Use Korean? (한국어로 진행할까요?) [y/N]: N
+
+Add a new agent
+
+── Identity ──
+Assistant ID (lowercase, e.g. hr): backend
+Display name (e.g. Backend) (Backend): Backend Dev
+Is this the leader (responds to all messages)? [y/N]: N
+
+── Character ──
+MBTI:
+  > 1. ENTJ — Strategist, decisive, big-picture leader
+    2. ISTJ — Rule-follower, systematic, accuracy-focused
+    3. ENFJ — People-oriented, empathetic, team harmony
+    4. INTP — Analytical, logical, deep explorer
+    5. Custom
+Choice (1): 2
+
+Speech style:
+  > 1. Formal to everyone
+    2. Formal to human + casual to peers
+    3. Custom
+Choice (1): 2
+
+Personality traits (with behavior examples, comma-separated):
+  e.g. "Systematic — structures all requirements, Cautious — verifies when unsure"
+  Traits: Detail-oriented — catches edge cases, Efficient — minimal code for max effect
+
+Habits (comma-separated):
+  e.g. "Reports in conclusion→evidence→next-steps order"
+  Habits: Always writes tests first, Documents API changes immediately
+
+── Role ──
+Core role (1-2 sentences): Backend developer handling API design, database, and server logic.
+
+Scope (comma-separated):
+  Scope: API development, Database design, Server architecture
+
+Not in scope (comma-separated):
+  Not in scope: UI/UX, Frontend styling
+
+Independent decisions: API structure, DB schema, code style
+Needs approval for: Major architecture changes, New framework adoption
+
+Expertise (comma-separated):
+  Expertise: Python, FastAPI, PostgreSQL, Docker
+
+Additional rules (comma-separated):
+  Rules: Always validate inputs, Never expose internal errors to clients
+
+Enable agent team mode (parallel sub-agents)? [y/N]: N
+
+── Engine ──
+Engine:
+  > 1. claude
+    2. codex
+    3. gemini
+Choice (1): 1
+Model (sonnet): opus
+Max budget per invocation ($) (10): 10
+
+── Tokens ──
+Discord bot token: MTIz...your-token-here
+
+── Channels ──
+Channel IDs this bot responds in (comma-separated, empty = all channels):
+  Channels:
+
+── Permissions ──
+Permission preset:
+    1. Full — can push, create PRs
+  > 2. Developer — can edit files, no push
+    3. Read-only — no edits, no push
+Choice (2): 1
+
+── Git identity ──
+Git author name (Backend Dev (mococo)): Backend Dev
+Git author email (backend@users.noreply.github.com):
+
+"Backend Dev" (backend) added successfully.
+  Config:  teams.json
+  Prompt:  prompts/backend.md  (editable)
+  Tokens:  .env
+
+Run `mococo start` to launch.
+```
+
+**What gets created:**
+- Entry in `teams.json` with all settings
+- `{ID}_DISCORD_TOKEN=...` appended to `.env`
+- `prompts/{id}.md` — auto-generated personality file (fully editable)
+
+---
+
+### `mococo edit <id>`
+
+Edit an existing assistant's configuration.
+
+```bash
+mococo edit backend
+```
+
+**Menu:**
+
+```
+Editing assistant "Backend Dev" (backend)
+
+What to edit:
+  > 1. name        — Display name
+    2. character   — MBTI, speech style, personality, habits
+    3. role        — Scope, authority, expertise
+    4. engine      — Engine and model
+    5. budget      — Max budget
+    6. channels    — Channel restrictions
+    7. permissions — Permission preset
+    8. git         — Git author identity
+    9. all         — Edit everything
+Choice (8):
+```
+
+- Editing **character** or **role** offers to regenerate the persona file (`prompts/{id}.md`)
+- You can edit individual sections or choose `all` to walk through everything
+
+---
+
+### `mococo list` / `mococo ls`
+
+Display all configured assistants in a table.
+
+```bash
+mococo list
+```
+
+**Example output:**
+
+```
+  ID               Name             Engine     Model              Leader
+  ──────────────── ──────────────── ────────── ────────────────── ──────
+  leader           Team Lead        claude     sonnet             yes
+  backend          Backend Dev      claude     opus
+  designer         Designer         gemini     gemini-2.5-pro
+```
+
+---
+
+### `mococo remove <id>` / `mococo rm <id>`
+
+Remove an assistant and clean up all related files.
+
+```bash
+mococo remove backend
+```
+
+**What gets removed:**
+- Entry from `teams.json`
+- `prompts/{id}.md` — personality file
+- `{ID}_*` token lines from `.env`
+
+---
+
+### `mococo start`
+
+Start all configured assistants.
+
+```bash
+mococo start
+```
+
+**What happens:**
+1. Loads `.env` from workspace
+2. Loads `teams.json` configuration
+3. Validates Discord tokens are present for each assistant
+4. Starts the HTTP hook receiver (default port: 9876)
+5. Creates Discord bots for each assistant with a valid token
+
+**Output:**
+
+```
+Starting 3 assistant(s)...
+mococo running — 3/3 assistants online (engines: claude, gemini)
+```
+
+**Requirements:**
+- Must run from within a mococo workspace (directory with `teams.json`)
+- Each assistant needs `{ID}_DISCORD_TOKEN` set in `.env`
+
+---
+
+### `mococo dev`
+
+Start in development mode with auto-rebuild. Watches for restart triggers.
+
+```bash
+mococo dev
+```
+
+Uses `nodemon` to watch for changes. When triggered, rebuilds TypeScript and restarts the bot.
+
+---
+
+### `mococo restart`
+
+Trigger a rebuild and restart when running in `dev` mode.
+
+```bash
+# In another terminal while `mococo dev` is running:
+mococo restart
+```
+
+---
+
+## Configuration Reference
+
+### teams.json
+
+Main configuration file. Created by `mococo init`, updated by `mococo add`/`edit`.
+
+```jsonc
+{
+  "teams": {
+    "leader": {
+      "name": "Team Lead",
+      "color": "#5865F2",
+      "avatar": "crown",
+      "engine": "claude",
+      "model": "sonnet",
+      "maxBudget": 10,
+      "prompt": "prompts/leader.md",
+      "isLeader": true,
+      "useTeams": false,
+      "channels": [],
+      "git": {
+        "name": "Team Lead",
+        "email": "leader@users.noreply.github.com"
+      },
+      "permissions": {
+        "allow": ["git push", "gh pr create"],
+        "deny": ["gh pr merge"]
+      },
+      "mcpServers": {}
+    }
+  },
+  "globalDeny": ["gh pr merge", "git push --force main", "git push --force master"],
+  "conversationWindow": 30,
+  "humanDiscordId": "123456789012345678",
+  "humanTitle": "Boss"
+}
+```
+
+**Per-assistant fields:**
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `name` | string | Display name in Discord |
+| `color` | hex string | Discord embed color |
+| `avatar` | string | Avatar key (`robot`, `crown`, `brain`, `gear`, `palette`, `shield`, `eye`, `test`, `book`) |
+| `engine` | string | `"claude"`, `"codex"`, or `"gemini"` |
+| `model` | string | Model name (e.g. `"sonnet"`, `"opus"`, `"o3"`, `"gemini-2.5-pro"`) |
+| `maxBudget` | number | Max dollar spend per invocation (Claude only) |
+| `prompt` | string | Path to the personality/instructions file |
+| `isLeader` | boolean | If `true`, responds to all messages (not just @mentions) |
+| `useTeams` | boolean | Enable agent team mode (parallel sub-agents) |
+| `teamRules` | string[] | Rules for sub-agent behavior |
+| `channels` | string[] | Channel IDs to respond in (empty = all) |
+| `discordUserId` | string | Auto-populated on first bot login |
+| `git.name` | string | Git commit author name |
+| `git.email` | string | Git commit author email |
+| `mcpServers` | object | MCP server configurations (env vars use `$VAR` syntax) |
+| `permissions.allow` | string[] | Allowed shell commands |
+| `permissions.deny` | string[] | Denied shell commands |
+
+**Global fields:**
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `globalDeny` | string[] | Commands denied for all assistants |
+| `conversationWindow` | number | Number of recent messages to include as context |
+| `humanDiscordId` | string | Your Discord user ID |
+| `humanTitle` | string | How assistants address you (e.g. "Boss", "Admin") |
+
+### .env
+
+Environment variables. Created by `mococo init`.
+
+```bash
+# Required
+WORK_CHANNEL_ID=1234567890123456   # Leave empty for all channels
+HOOK_PORT=9876                      # HTTP webhook receiver port
+
+# Optional
+MEMBER_TRACKING_CHANNEL_ID=         # Channel for member events
+DECISION_LOG_CHANNEL_ID=            # Channel for leader decision logs
+GITHUB_TOKEN=ghp_xxxxx             # GitHub PAT for push/PR operations
+
+# One per assistant (auto-added by `mococo add`)
+LEADER_DISCORD_TOKEN=your-token-here
+BACKEND_DISCORD_TOKEN=your-token-here
+```
+
+### prompts/{id}.md
+
+Auto-generated personality file. Fully editable — this is where each assistant's character, role, and rules are defined.
+
+**Generated structure:**
+
+```markdown
+# Assistant Name
+
+You are **Assistant Name**, an AI assistant on Discord.
+When addressing the human, always call them **Boss**.
+
+## Character
+- **MBTI:** ISTJ — Rule-follower, systematic, accuracy-focused
+- **Speech style:**
+  - To the human: strictly formal and respectful
+  - To other agents: casual and direct
+- **Personality:**
+  - Detail-oriented — catches edge cases
+- **Habits:**
+  - Always writes tests first
+
+## Role
+Backend developer handling API design and server logic.
+
+**Scope:**
+- API development
+- Database design
+
+**Not in scope:**
+- UI/UX
+
+**Decision authority:**
+- Independent: API structure, DB schema
+- Needs approval: Major architecture changes
+
+## Expertise
+- Python
+- FastAPI
+
+## Rules
+- Always validate inputs
+```
+
+### prompts/shared-rules.md
+
+Common rules automatically included for all assistants. Copied from `defaults/shared-rules.md` during `mococo init`. Covers:
+- Priority hierarchy (Rules > Role > Personality)
+- Command chain (human > leader > self)
+- Absolute prohibitions (no merging, no credential exposure)
+- Tag and conversation management
+- Memory and behavior guidelines
+- New agent welcome protocol
+
+Uses `{{humanTitle}}` and `{{leaderName}}` placeholders that are replaced at runtime.
+
+---
+
+## Usage Scenarios
+
+### Scenario 1: Single Assistant
+
+The simplest setup — one bot that handles everything.
+
+```bash
+mkdir my-project && cd my-project
+mococo init
+mococo add
+# → ID: assistant, Engine: claude, Model: opus
+# → Permission: Full
+
+ln -s /path/to/my-app repos/my-app
+mococo start
+```
+
+Now mention `@assistant` in Discord:
+
+```
+You: @assistant Add input validation to the signup form
+Bot: I'll add validation for email format, password strength, and required fields.
+     → makes changes → commits → pushes → opens PR
+```
+
+### Scenario 2: Multi-Assistant Team
+
+A team with a leader that delegates to specialists.
+
+```bash
+mkdir my-team && cd my-team
+mococo init
+
+# Add a leader (responds to all messages, delegates work)
+mococo add
+# → ID: leader, isLeader: yes, Engine: claude, Model: sonnet
+# → Permission: Read-only (leader doesn't code — it delegates)
+
+# Add a backend developer
+mococo add
+# → ID: backend, Engine: claude, Model: opus
+# → Permission: Full
+
+# Add a frontend developer
+mococo add
+# → ID: frontend, Engine: claude, Model: opus
+# → Permission: Full
+
+# Link repos
+ln -s /path/to/api repos/api
+ln -s /path/to/web repos/web
+mococo start
+```
+
+Now talk in the Discord channel (no @mention needed — the leader picks it up):
+
+```
+You: Build a user profile page with an API endpoint
+
+Leader: I'll coordinate this.
+        @backend Create GET /api/users/:id endpoint
+        @frontend Build the profile page component
+
+Backend: Working on the API endpoint...
+         → commits code → pushes → opens PR
+
+Frontend: Building the profile component...
+          → commits code → pushes → opens PR
+```
 
 ---
 
 ## How It Works
 
 **Message routing:**
-- If you `@mention` a specific bot → that assistant responds
-- If no mention → the first assistant marked `"isLeader": true` responds
+- `@mention` a specific bot → that assistant responds
+- No mention → the assistant marked `"isLeader": true` responds
 
-**When an assistant mentions another** (e.g. `@Reviewer please check this`) → that assistant is automatically invoked.
+**Cross-assistant invocation:**
+When an assistant mentions another (e.g. `@Backend please check this`) → that assistant is automatically invoked.
 
-**Permissions** are controlled per-assistant in `teams.json`:
+**Engines:**
+- `"claude"` — Full agent with file editing, git operations, shell commands
+- `"codex"` — Text-only advisor
+- `"gemini"` — Text-only advisor
+
+**Permissions** are controlled per-assistant:
 
 ```jsonc
 "permissions": {
-  "allow": ["git push", "gh pr create"],
-  "deny": ["gh pr merge"]
+  "allow": ["git push", "gh pr create"],   // explicitly allowed
+  "deny": ["gh pr merge"]                   // explicitly denied
 }
 ```
 
-**Engines:** `"claude"` runs as a full agent (files, git, commands). `"codex"` and `"gemini"` run as text-only advisors.
-
----
-
-## Configuration Reference
-
-### teams.json fields
-
-| Field | Description |
-|-------|-------------|
-| `engine` | `"claude"`, `"codex"`, or `"gemini"` |
-| `model` | Model name (e.g. `"sonnet"`, `"opus"`, `"o3"`, `"gemini-2.5-pro"`) |
-| `maxBudget` | Max dollar spend per invocation (Claude only) |
-| `prompt` | Path to the personality/instructions file |
-| `isLeader` | If `true`, responds to all messages (not just @mentions) |
-| `git.name` / `git.email` | Git author for commits |
-| `permissions.allow` / `permissions.deny` | Allowed/denied shell commands |
-
-### Discord commands
+**Discord commands** (type in chat):
 
 | Command | Description |
 |---------|-------------|
@@ -142,14 +611,39 @@ Or just run a single assistant. It's up to you.
 
 ---
 
+## Workspace Structure
+
+After setup, your workspace looks like this:
+
+```
+my-team/
+├── teams.json              # Assistant configurations
+├── .env                    # Tokens and settings
+├── .gitignore              # Excludes .env, .mococo/, repos/*
+├── prompts/
+│   ├── shared-rules.md     # Common rules for all assistants
+│   ├── leader.md           # Leader personality
+│   ├── backend.md          # Backend personality
+│   └── frontend.md         # Frontend personality
+├── repos/
+│   ├── .gitkeep
+│   ├── api -> /path/to/api         # Symlink
+│   └── web -> /path/to/web         # Symlink
+├── hooks/                  # Claude Code git hooks
+└── .mococo/                # Internal state
+```
+
+---
+
 ## Manual Setup (without CLI)
 
 You can also set up manually by cloning the repo:
 
 ```bash
-git clone https://github.com/anthropics/claude-mococo.git
+git clone https://github.com/wodn5515/claude-mococo.git
 cd claude-mococo
 npm install
+npm run build
 ```
 
 Edit `teams.json` directly, create prompt files in `prompts/`, set tokens in `.env`, then `npm start`.
@@ -161,10 +655,13 @@ Edit `teams.json` directly, create prompt files in `prompts/`, set tokens in `.e
 | Problem | Fix |
 |---------|-----|
 | Bot doesn't respond | Enable **Message Content Intent** in Discord Developer Portal |
-| "No team has a Discord token" | Add the token env var to `.env` |
-| Can't push to GitHub | Check the GitHub PAT in `.env` is valid |
+| "No assistant has a Discord token" | Add the token to `.env` (`{ID}_DISCORD_TOKEN=...`) |
+| Can't push to GitHub | Set `GITHUB_TOKEN` in `.env` with a valid PAT |
 | Wrong commit author | Set `git.email` to `USERNAME@users.noreply.github.com` |
-| "command not found: codex" | Install it or change engine to `"claude"` |
+| "command not found: codex" | Install it (`npm i -g @openai/codex`) or change engine to `"claude"` |
+| Bot responds in wrong channel | Set `channels` in `teams.json` or `WORK_CHANNEL_ID` in `.env` |
+
+---
 
 ## License
 

--- a/src/cli/commands/add.ts
+++ b/src/cli/commands/add.ts
@@ -3,6 +3,10 @@ import path from 'node:path';
 import { ask, confirm, choose, closeRL } from '../readline-utils.js';
 import { generatePrompt } from '../prompt-template.js';
 import { requireWorkspace } from '../workspace.js';
+import {
+  t, isLangExplicit, setLang,
+  getMbtiPresets, getSpeechPresets, getPermissionPresets,
+} from '../i18n.js';
 
 const ENGINE_DEFAULTS: Record<string, string> = {
   claude: 'sonnet',
@@ -10,43 +14,15 @@ const ENGINE_DEFAULTS: Record<string, string> = {
   gemini: 'gemini-2.5-pro',
 };
 
-const PERMISSION_PRESETS: Record<string, { allow?: string[]; deny?: string[] }> = {
-  'Full — can push, create PRs': {
-    allow: ['git push', 'gh pr create'],
-    deny: ['gh pr merge'],
-  },
-  'Developer — can edit files, no push': {
-    deny: ['git push', 'gh pr'],
-  },
-  'Read-only — no edits, no push': {
-    deny: ['git push', 'gh pr', 'Edit', 'Write'],
-  },
-};
-
 const AVATAR_KEYS = ['robot', 'crown', 'brain', 'gear', 'palette', 'shield', 'eye', 'test', 'book'];
 
-const MBTI_PRESETS: Record<string, string> = {
-  'ENTJ — Strategist, decisive, big-picture leader': 'ENTJ — Strategist, decisive, big-picture leader',
-  'ISTJ — Rule-follower, systematic, accuracy-focused': 'ISTJ — Rule-follower, systematic, accuracy-focused',
-  'ENFJ — People-oriented, empathetic, team harmony': 'ENFJ — People-oriented, empathetic, team harmony',
-  'INTP — Analytical, logical, deep explorer': 'INTP — Analytical, logical, deep explorer',
-  'Custom': '',
-};
-
-const SPEECH_PRESETS: Record<string, string> = {
-  'Formal to everyone': [
-    '  - To the human: formal and respectful',
-    '  - To the leader: formal and respectful',
-    '  - To other agents: polite and professional',
-  ].join('\n'),
-  'Formal to human + casual to peers': [
-    '  - To the human: strictly formal and respectful',
-    '  - To other agents: casual and direct',
-  ].join('\n'),
-  'Custom': '',
-};
-
 export async function runAdd(): Promise<void> {
+  // Language selection if --lang not specified
+  if (!isLangExplicit()) {
+    const useKo = await confirm(t('lang.prompt'), false);
+    if (useKo) setLang('ko', true);
+  }
+
   const ws = requireWorkspace();
   const teamsJsonPath = path.join(ws, 'teams.json');
   const raw = JSON.parse(fs.readFileSync(teamsJsonPath, 'utf-8'));
@@ -54,40 +30,42 @@ export async function runAdd(): Promise<void> {
   // Load humanTitle from config for prompt generation
   const humanTitle: string = raw.humanTitle ?? 'Boss';
 
-  console.log('Add a new agent\n');
+  console.log(t('add.title'));
 
   // --- Identity ---
-  console.log('── Identity ──');
-  const id = await ask('Assistant ID (lowercase, e.g. hr)');
+  console.log(t('add.identity'));
+  const id = await ask(t('add.askId'));
   if (!id || !/^[a-z][a-z0-9_-]*$/.test(id)) {
-    console.error('ID must be lowercase alphanumeric (start with letter).');
+    console.error(t('add.badId'));
     process.exit(1);
   }
   if (raw.teams[id]) {
-    console.error(`Assistant "${id}" already exists.`);
+    console.error(`"${id}" ${t('add.dupId')}`);
     process.exit(1);
   }
 
-  const name = await ask('Display name (e.g. Backend)', id.charAt(0).toUpperCase() + id.slice(1));
-  const isLeader = await confirm('Is this the leader (responds to all messages)?', false);
+  const name = await ask(t('add.askName'), id.charAt(0).toUpperCase() + id.slice(1));
+  const isLeader = await confirm(t('add.askLeader'), false);
 
   // --- Character ---
-  console.log('\n── Character ──');
+  console.log(t('add.character'));
 
   // MBTI
+  const MBTI_PRESETS = getMbtiPresets();
   const mbtiNames = Object.keys(MBTI_PRESETS);
-  const mbtiChoice = await choose('MBTI:', mbtiNames, 0);
+  const mbtiChoice = await choose(t('shared.mbti'), mbtiNames, 0);
   let mbti = MBTI_PRESETS[mbtiChoice];
   if (!mbti) {
-    mbti = await ask('MBTI (e.g. ISFJ — Diligent, caring, executor)');
+    mbti = await ask(t('add.askMbtiCustom'));
   }
 
   // Speech style
+  const SPEECH_PRESETS = getSpeechPresets();
   const speechNames = Object.keys(SPEECH_PRESETS);
-  const speechChoice = await choose('Speech style:', speechNames, 0);
+  const speechChoice = await choose(t('shared.speech'), speechNames, 0);
   let speechStyle = SPEECH_PRESETS[speechChoice];
   if (!speechStyle) {
-    console.log('Enter speech style line by line (empty line to finish):');
+    console.log(t('add.speechCustom'));
     const lines: string[] = [];
     let line = await ask('  ');
     while (line) {
@@ -98,94 +76,95 @@ export async function runAdd(): Promise<void> {
   }
 
   // Traits
-  console.log('Personality traits (with behavior examples, comma-separated):');
-  console.log('  e.g. "Systematic — structures all requirements, Cautious — verifies when unsure"');
-  const traitsStr = await ask('  Traits', '');
+  console.log(t('add.askTraits'));
+  console.log(t('add.traitsEx'));
+  const traitsStr = await ask(t('shared.traits'), '');
   const traits = traitsStr
     ? traitsStr.split(',').map(s => s.trim()).filter(Boolean)
     : [];
 
   // Habits
-  console.log('Habits (comma-separated):');
-  console.log('  e.g. "Reports in conclusion→evidence→next-steps order, Ends delegations with clear directives"');
-  const habitsStr = await ask('  Habits', '');
+  console.log(t('add.askHabits'));
+  console.log(t('add.habitsEx'));
+  const habitsStr = await ask(t('shared.habits'), '');
   const habits = habitsStr
     ? habitsStr.split(',').map(s => s.trim()).filter(Boolean)
     : [];
 
   // --- Role ---
-  console.log('\n── Role ──');
-  const role = await ask('Core role (1-2 sentences)');
+  console.log(t('add.role'));
+  const role = await ask(t('add.askRole'));
 
-  console.log('Scope (comma-separated):');
-  const scopeStr = await ask('  Scope', '');
+  console.log(t('add.askScope'));
+  const scopeStr = await ask(t('shared.scope'), '');
   const scope = scopeStr
     ? scopeStr.split(',').map(s => s.trim()).filter(Boolean)
     : [];
 
-  console.log('Not in scope (comma-separated):');
-  const notScopeStr = await ask('  Not in scope', '');
+  console.log(t('add.askNotScope'));
+  const notScopeStr = await ask(t('shared.notScope'), '');
   const notScope = notScopeStr
     ? notScopeStr.split(',').map(s => s.trim()).filter(Boolean)
     : [];
 
-  const authorityIndependent = await ask('Independent decisions', '');
-  const authorityNeedsApproval = await ask('Needs approval for', '');
+  const authorityIndependent = await ask(t('add.askAuthIndep'), '');
+  const authorityNeedsApproval = await ask(t('add.askAuthApproval'), '');
 
   // Expertise
-  console.log('Expertise (comma-separated):');
-  const expertiseStr = await ask('  Expertise', '');
+  console.log(t('add.askExpertise'));
+  const expertiseStr = await ask(t('shared.expertise'), '');
   const expertise = expertiseStr
     ? expertiseStr.split(',').map(s => s.trim()).filter(Boolean)
     : [];
 
   // Custom rules
-  console.log('Additional rules (comma-separated):');
-  const rulesStr = await ask('  Rules', '');
+  console.log(t('add.askRules'));
+  const rulesStr = await ask(t('shared.rules'), '');
   const rules = rulesStr
     ? rulesStr.split(',').map(s => s.trim()).filter(Boolean)
     : [];
 
   // Agent teams
-  const useTeams = await confirm('Enable agent team mode (parallel sub-agents)?', false);
+  const useTeams = await confirm(t('add.askTeams'), false);
   let teamRules: string[] = [];
   if (useTeams) {
-    console.log('Team rules (comma-separated):');
-    const teamRulesStr = await ask('  Team rules', '');
+    console.log(t('add.askTeamRules'));
+    const teamRulesStr = await ask(t('shared.teamRules'), '');
     teamRules = teamRulesStr
       ? teamRulesStr.split(',').map(s => s.trim()).filter(Boolean)
       : [];
   }
 
   // --- Engine ---
-  console.log('\n── Engine ──');
+  console.log(t('add.engine'));
   const engine = await choose('Engine:', ['claude', 'codex', 'gemini'], 0);
-  const model = await ask('Model', ENGINE_DEFAULTS[engine] ?? 'sonnet');
-  const budgetStr = await ask('Max budget per invocation ($)', '10');
+  const model = await ask(t('add.askModel'), ENGINE_DEFAULTS[engine] ?? 'sonnet');
+  const budgetStr = await ask(t('add.askBudget'), '10');
   const maxBudget = parseFloat(budgetStr) || 10;
 
   // --- Tokens ---
-  console.log('\n── Tokens ──');
-  const discordToken = await ask('Discord bot token');
+  console.log(t('add.tokens'));
+  const discordToken = await ask(t('add.askToken'));
 
   // --- Channels ---
-  console.log('\n── Channels ──');
-  console.log('Channel IDs this bot responds in (comma-separated, empty = all channels):');
-  const channelsStr = await ask('  Channels', '');
+  console.log(t('add.channels'));
+  console.log(t('add.askChannels'));
+  const channelsStr = await ask(t('shared.channels'), '');
   const channels = channelsStr
     ? channelsStr.split(',').map(s => s.trim()).filter(Boolean)
     : [];
 
   // --- Permissions ---
-  console.log('\n── Permissions ──');
+  console.log(t('add.permissions'));
+  const PERMISSION_PRESETS = getPermissionPresets();
   const presetNames = Object.keys(PERMISSION_PRESETS);
-  const presetChoice = await choose('Permission preset:', presetNames, 1);
+  const presetChoice = await choose(t('shared.permPreset'), presetNames, 1);
   const permissions = PERMISSION_PRESETS[presetChoice] ?? {};
 
   // --- Git identity ---
-  console.log('\n── Git identity ──');
-  const gitName = await ask('Git author name', `${name} (mococo)`);
-  const gitEmail = await ask('Git author email', `${id}@users.noreply.github.com`);
+  console.log(t('add.git'));
+  const gitName = await ask(t('add.askGitName'), `${name} (mococo)`);
+  const gitEmail = await ask(t('add.askGitEmail'), `${id}@users.noreply.github.com`);
 
   // Pick an avatar
   const usedAvatars = new Set(Object.values(raw.teams as Record<string, any>).map((t: any) => t.avatar));
@@ -227,9 +206,9 @@ export async function runAdd(): Promise<void> {
     }));
   }
 
-  console.log(`\nAgent "${name}" (${id}) added successfully.`);
-  console.log(`  Config:  teams.json`);
-  console.log(`  Prompt:  prompts/${id}.md  (editable)`);
-  console.log(`  Tokens:  .env`);
-  console.log(`\nRun \`mococo start\` to launch.`);
+  console.log(`\n"${name}" (${id}) ${t('add.done')}`);
+  console.log(t('add.configLine'));
+  console.log(`${t('add.promptLine')}  prompts/${id}.md  (editable)`);
+  console.log(t('add.tokenLine'));
+  console.log(t('add.launch'));
 }

--- a/src/cli/commands/edit.ts
+++ b/src/cli/commands/edit.ts
@@ -3,6 +3,10 @@ import path from 'node:path';
 import { ask, confirm, choose, closeRL } from '../readline-utils.js';
 import { generatePrompt } from '../prompt-template.js';
 import { requireWorkspace } from '../workspace.js';
+import {
+  t, isLangExplicit, setLang,
+  getMbtiPresets, getSpeechPresets, getPermissionPresets, getEditFields,
+} from '../i18n.js';
 
 const ENGINE_DEFAULTS: Record<string, string> = {
   claude: 'sonnet',
@@ -10,56 +14,16 @@ const ENGINE_DEFAULTS: Record<string, string> = {
   gemini: 'gemini-2.5-pro',
 };
 
-const PERMISSION_PRESETS: Record<string, { allow?: string[]; deny?: string[] }> = {
-  'Full — can push, create PRs': {
-    allow: ['git push', 'gh pr create'],
-    deny: ['gh pr merge'],
-  },
-  'Developer — can edit files, no push': {
-    deny: ['git push', 'gh pr'],
-  },
-  'Read-only — no edits, no push': {
-    deny: ['git push', 'gh pr', 'Edit', 'Write'],
-  },
-};
-
-const MBTI_PRESETS: Record<string, string> = {
-  'ENTJ — Strategist, decisive, big-picture leader': 'ENTJ — Strategist, decisive, big-picture leader',
-  'ISTJ — Rule-follower, systematic, accuracy-focused': 'ISTJ — Rule-follower, systematic, accuracy-focused',
-  'ENFJ — People-oriented, empathetic, team harmony': 'ENFJ — People-oriented, empathetic, team harmony',
-  'INTP — Analytical, logical, deep explorer': 'INTP — Analytical, logical, deep explorer',
-  'Custom': '',
-};
-
-const SPEECH_PRESETS: Record<string, string> = {
-  'Formal to everyone': [
-    '  - To the human: formal and respectful',
-    '  - To the leader: formal and respectful',
-    '  - To other agents: polite and professional',
-  ].join('\n'),
-  'Formal to human + casual to peers': [
-    '  - To the human: strictly formal and respectful',
-    '  - To other agents: casual and direct',
-  ].join('\n'),
-  'Custom': '',
-};
-
-const EDIT_FIELDS = [
-  'name        — Display name',
-  'character   — MBTI, speech style, personality, habits',
-  'role        — Scope, authority, expertise',
-  'engine      — Engine and model',
-  'budget      — Max budget',
-  'channels    — Channel restrictions',
-  'permissions — Permission preset',
-  'git         — Git author identity',
-  'all         — Edit everything',
-];
-
 export async function runEdit(id: string): Promise<void> {
   if (!id) {
-    console.error('Usage: mococo edit <assistant-id>');
+    console.error(t('edit.usage'));
     process.exit(1);
+  }
+
+  // Language selection if --lang not specified
+  if (!isLangExplicit()) {
+    const useKo = await confirm(t('lang.prompt'), false);
+    if (useKo) setLang('ko', true);
   }
 
   const ws = requireWorkspace();
@@ -71,24 +35,25 @@ export async function runEdit(id: string): Promise<void> {
   const humanTitle: string = raw.humanTitle ?? 'Boss';
 
   if (!team) {
-    console.error(`Assistant "${id}" not found.`);
+    console.error(`"${id}" ${t('edit.notFound')}`);
     const ids = Object.keys(raw.teams);
     if (ids.length > 0) {
-      console.error(`Available: ${ids.join(', ')}`);
+      console.error(`${t('edit.available')} ${ids.join(', ')}`);
     }
     process.exit(1);
   }
 
-  console.log(`Editing assistant "${team.name}" (${id})\n`);
+  console.log(`${t('edit.title')} "${team.name}" (${id})\n`);
 
-  const fieldChoice = await choose('What to edit:', EDIT_FIELDS, 7);
+  const EDIT_FIELDS = getEditFields();
+  const fieldChoice = await choose(t('edit.what'), EDIT_FIELDS, 7);
   const field = fieldChoice.split(' ')[0];
 
   const editAll = field === 'all';
 
   // Name
   if (editAll || field === 'name') {
-    team.name = await ask('Display name', team.name);
+    team.name = await ask(t('add.askName'), team.name);
   }
 
   // Character & Role → regenerate prompt
@@ -108,20 +73,22 @@ export async function runEdit(id: string): Promise<void> {
 
   if (editAll || field === 'character' || field === 'role') {
     if (editAll || field === 'character') {
-      console.log('\n── Character ──');
+      console.log(t('add.character'));
 
+      const MBTI_PRESETS = getMbtiPresets();
       const mbtiNames = Object.keys(MBTI_PRESETS);
-      const mbtiChoice = await choose('MBTI:', mbtiNames, 0);
+      const mbtiChoice = await choose(t('shared.mbti'), mbtiNames, 0);
       mbti = MBTI_PRESETS[mbtiChoice];
       if (!mbti) {
-        mbti = await ask('MBTI (e.g. ISFJ — Diligent, caring, executor)');
+        mbti = await ask(t('add.askMbtiCustom'));
       }
 
+      const SPEECH_PRESETS = getSpeechPresets();
       const speechNames = Object.keys(SPEECH_PRESETS);
-      const speechChoice = await choose('Speech style:', speechNames, 0);
+      const speechChoice = await choose(t('shared.speech'), speechNames, 0);
       speechStyle = SPEECH_PRESETS[speechChoice];
       if (!speechStyle) {
-        console.log('Enter speech style line by line (empty line to finish):');
+        console.log(t('add.speechCustom'));
         const lines: string[] = [];
         let line = await ask('  ');
         while (line) {
@@ -131,39 +98,39 @@ export async function runEdit(id: string): Promise<void> {
         speechStyle = lines.join('\n');
       }
 
-      console.log('Personality traits (with behavior examples, comma-separated):');
-      const traitsStr = await ask('  Traits', '');
+      console.log(t('add.askTraits'));
+      const traitsStr = await ask(t('shared.traits'), '');
       traits = traitsStr ? traitsStr.split(',').map(s => s.trim()).filter(Boolean) : [];
 
-      console.log('Habits (comma-separated):');
-      const habitsStr = await ask('  Habits', '');
+      console.log(t('add.askHabits'));
+      const habitsStr = await ask(t('shared.habits'), '');
       habits = habitsStr ? habitsStr.split(',').map(s => s.trim()).filter(Boolean) : [];
     }
 
     if (editAll || field === 'role') {
-      console.log('\n── Role ──');
-      role = await ask('Core role (1-2 sentences)', '');
+      console.log(t('add.role'));
+      role = await ask(t('add.askRole'), '');
 
-      console.log('Scope (comma-separated):');
-      const scopeStr = await ask('  Scope', '');
+      console.log(t('add.askScope'));
+      const scopeStr = await ask(t('shared.scope'), '');
       scope = scopeStr ? scopeStr.split(',').map(s => s.trim()).filter(Boolean) : [];
 
-      console.log('Not in scope (comma-separated):');
-      const notScopeStr = await ask('  Not in scope', '');
+      console.log(t('add.askNotScope'));
+      const notScopeStr = await ask(t('shared.notScope'), '');
       notScope = notScopeStr ? notScopeStr.split(',').map(s => s.trim()).filter(Boolean) : [];
 
-      authorityIndependent = await ask('Independent decisions', '');
-      authorityNeedsApproval = await ask('Needs approval for', '');
+      authorityIndependent = await ask(t('add.askAuthIndep'), '');
+      authorityNeedsApproval = await ask(t('add.askAuthApproval'), '');
 
-      console.log('Expertise (comma-separated):');
-      const expertiseStr = await ask('  Expertise', '');
+      console.log(t('add.askExpertise'));
+      const expertiseStr = await ask(t('shared.expertise'), '');
       expertise = expertiseStr ? expertiseStr.split(',').map(s => s.trim()).filter(Boolean) : [];
 
-      console.log('Additional rules (comma-separated):');
-      const rulesStr = await ask('  Rules', '');
+      console.log(t('add.askRules'));
+      const rulesStr = await ask(t('shared.rules'), '');
       rules = rulesStr ? rulesStr.split(',').map(s => s.trim()).filter(Boolean) : [];
 
-      isLeader = await confirm('Is this the leader?', team.isLeader ?? false);
+      isLeader = await confirm(t('shared.isLeader'), team.isLeader ?? false);
       if (isLeader) {
         team.isLeader = true;
       } else {
@@ -171,7 +138,7 @@ export async function runEdit(id: string): Promise<void> {
       }
     }
 
-    regeneratePrompt = await confirm('Regenerate persona file? (overwrites existing)', true);
+    regeneratePrompt = await confirm(t('edit.regen'), true);
   }
 
   // Engine
@@ -179,21 +146,21 @@ export async function runEdit(id: string): Promise<void> {
     const engine = await choose('Engine:', ['claude', 'codex', 'gemini'],
       ['claude', 'codex', 'gemini'].indexOf(team.engine));
     team.engine = engine;
-    team.model = await ask('Model', team.model ?? ENGINE_DEFAULTS[engine]);
+    team.model = await ask(t('add.askModel'), team.model ?? ENGINE_DEFAULTS[engine]);
   }
 
   // Budget
   if (editAll || field === 'budget') {
-    const budgetStr = await ask('Max budget per invocation ($)', String(team.maxBudget ?? 10));
+    const budgetStr = await ask(t('add.askBudget'), String(team.maxBudget ?? 10));
     team.maxBudget = parseFloat(budgetStr) || 10;
   }
 
   // Channels
   if (editAll || field === 'channels') {
     const current = (team.channels ?? []).join(', ');
-    console.log(`Current channels: ${current || '(all channels)'}`);
-    console.log('Channel IDs (comma-separated, empty = all channels):');
-    const channelsStr = await ask('  Channels', current);
+    console.log(`${t('shared.currentCh')} ${current || t('shared.allCh')}`);
+    console.log(t('shared.chGuide'));
+    const channelsStr = await ask(t('shared.channels'), current);
     const channels = channelsStr
       ? channelsStr.split(',').map((s: string) => s.trim()).filter(Boolean)
       : [];
@@ -206,16 +173,17 @@ export async function runEdit(id: string): Promise<void> {
 
   // Permissions
   if (editAll || field === 'permissions') {
+    const PERMISSION_PRESETS = getPermissionPresets();
     const presetNames = Object.keys(PERMISSION_PRESETS);
-    const presetChoice = await choose('Permission preset:', presetNames, 1);
+    const presetChoice = await choose(t('shared.permPreset'), presetNames, 1);
     team.permissions = PERMISSION_PRESETS[presetChoice] ?? {};
   }
 
   // Git identity
   if (editAll || field === 'git') {
     const git = team.git ?? {};
-    git.name = await ask('Git author name', git.name ?? `${team.name} (mococo)`);
-    git.email = await ask('Git author email', git.email ?? `${id}@users.noreply.github.com`);
+    git.name = await ask(t('add.askGitName'), git.name ?? `${team.name} (mococo)`);
+    git.email = await ask(t('add.askGitEmail'), git.email ?? `${id}@users.noreply.github.com`);
     team.git = git;
   }
 
@@ -240,8 +208,8 @@ export async function runEdit(id: string): Promise<void> {
       isLeader,
       humanTitle,
     }));
-    console.log(`  Persona regenerated: prompts/${id}.md`);
+    console.log(`${t('edit.regenDone')} prompts/${id}.md`);
   }
 
-  console.log(`\nAgent "${team.name}" (${id}) updated successfully.`);
+  console.log(`\n"${team.name}" (${id}) ${t('edit.done')}`);
 }

--- a/src/cli/commands/init.ts
+++ b/src/cli/commands/init.ts
@@ -2,6 +2,7 @@ import fs from 'node:fs';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { ask, confirm, closeRL } from '../readline-utils.js';
+import { t, isLangExplicit, setLang } from '../i18n.js';
 
 function getPackageRoot(): string {
   // Resolve from dist/cli/commands/init.js → package root
@@ -23,18 +24,24 @@ function copyDir(src: string, dest: string): void {
 }
 
 export async function runInit(): Promise<void> {
+  // Language selection if --lang not specified
+  if (!isLangExplicit()) {
+    const useKo = await confirm(t('lang.prompt'), false);
+    if (useKo) setLang('ko', true);
+  }
+
   const cwd = process.cwd();
   const teamsJsonPath = path.join(cwd, 'teams.json');
   const isReinit = fs.existsSync(teamsJsonPath);
 
   if (isReinit) {
-    console.log('Existing workspace detected. Updating settings...\n');
+    console.log(t('init.existing'));
   } else {
-    console.log('Initializing workspace...\n');
+    console.log(t('init.fresh'));
   }
 
-  const channelId = await ask('Discord work channel ID (leave empty for all channels)');
-  const humanId = await ask('Your Discord user ID (right-click your name → Copy User ID)');
+  const channelId = await ask(t('init.askChannel'));
+  const humanId = await ask(t('init.askHumanId'));
 
   if (isReinit) {
     // Update existing teams.json — preserve teams, update global settings
@@ -112,23 +119,23 @@ export async function runInit(): Promise<void> {
     }
   } else if (!fs.existsSync(destHooks)) {
     fs.mkdirSync(destHooks, { recursive: true });
-    console.warn('Warning: hooks/ not found in package. You may need to copy them manually.');
+    console.warn(t('init.hooksWarn'));
   }
 
   closeRL();
 
   if (isReinit) {
-    console.log('\nWorkspace updated.');
-    console.log('  teams.json   — settings updated (assistants preserved)');
-    console.log('  .env         — channel/port updated (tokens preserved)');
-    console.log('  hooks/       — refreshed from package');
+    console.log(t('init.updated'));
+    console.log(t('init.updatedTeams'));
+    console.log(t('init.updatedEnv'));
+    console.log(t('init.updatedHooks'));
   } else {
-    console.log('\nWorkspace created:');
-    console.log('  teams.json   — assistant configuration');
-    console.log('  .env         — tokens and settings');
-    console.log('  prompts/     — personality files');
-    console.log('  repos/       — linked repositories');
-    console.log('  hooks/       — Claude Code hooks');
-    console.log('\nNext: run `mococo add` to add your first assistant.');
+    console.log(t('init.created'));
+    console.log(t('init.createdTeams'));
+    console.log(t('init.createdEnv'));
+    console.log(t('init.createdPrompts'));
+    console.log(t('init.createdRepos'));
+    console.log(t('init.createdHooks'));
+    console.log(t('init.next'));
   }
 }

--- a/src/cli/i18n.ts
+++ b/src/cli/i18n.ts
@@ -1,0 +1,240 @@
+export type Lang = 'en' | 'ko';
+
+let currentLang: Lang = 'en';
+let langExplicit = false;
+
+export function setLang(lang: Lang, explicit = false): void {
+  currentLang = lang;
+  if (explicit) langExplicit = true;
+}
+
+export function getLang(): Lang {
+  return currentLang;
+}
+
+export function isLangExplicit(): boolean {
+  return langExplicit;
+}
+
+/* ── Localised presets (shared by add & edit) ── */
+
+export function getMbtiPresets(): Record<string, string> {
+  if (currentLang === 'ko') {
+    return {
+      'ENTJ — 전략가, 결단력, 큰 그림을 보는 리더': 'ENTJ — 전략가, 결단력, 큰 그림을 보는 리더',
+      'ISTJ — 규칙 준수, 체계적, 정확성 중심': 'ISTJ — 규칙 준수, 체계적, 정확성 중심',
+      'ENFJ — 사람 중심, 공감 능력, 팀 조화': 'ENFJ — 사람 중심, 공감 능력, 팀 조화',
+      'INTP — 분석적, 논리적, 깊이 파는 탐구자': 'INTP — 분석적, 논리적, 깊이 파는 탐구자',
+      '직접 입력': '',
+    };
+  }
+  return {
+    'ENTJ — Strategist, decisive, big-picture leader': 'ENTJ — Strategist, decisive, big-picture leader',
+    'ISTJ — Rule-follower, systematic, accuracy-focused': 'ISTJ — Rule-follower, systematic, accuracy-focused',
+    'ENFJ — People-oriented, empathetic, team harmony': 'ENFJ — People-oriented, empathetic, team harmony',
+    'INTP — Analytical, logical, deep explorer': 'INTP — Analytical, logical, deep explorer',
+    'Custom': '',
+  };
+}
+
+export function getSpeechPresets(): Record<string, string> {
+  if (currentLang === 'ko') {
+    return {
+      '모두에게 존댓말': [
+        '  - 사람에게: 정중하고 격식 있는 존댓말',
+        '  - 리더에게: 정중하고 격식 있는 존댓말',
+        '  - 다른 에이전트에게: 예의 바르고 전문적인 말투',
+      ].join('\n'),
+      '사람에게 존댓말 + 동료에게 반말': [
+        '  - 사람에게: 엄격하게 정중한 존댓말',
+        '  - 다른 에이전트에게: 편한 반말',
+      ].join('\n'),
+      '직접 입력': '',
+    };
+  }
+  return {
+    'Formal to everyone': [
+      '  - To the human: formal and respectful',
+      '  - To the leader: formal and respectful',
+      '  - To other agents: polite and professional',
+    ].join('\n'),
+    'Formal to human + casual to peers': [
+      '  - To the human: strictly formal and respectful',
+      '  - To other agents: casual and direct',
+    ].join('\n'),
+    'Custom': '',
+  };
+}
+
+export function getPermissionPresets(): Record<string, { allow?: string[]; deny?: string[] }> {
+  if (currentLang === 'ko') {
+    return {
+      '전체 — 푸시, PR 생성 가능': {
+        allow: ['git push', 'gh pr create'],
+        deny: ['gh pr merge'],
+      },
+      '개발자 — 파일 수정 가능, 푸시 불가': {
+        deny: ['git push', 'gh pr'],
+      },
+      '읽기 전용 — 수정 불가, 푸시 불가': {
+        deny: ['git push', 'gh pr', 'Edit', 'Write'],
+      },
+    };
+  }
+  return {
+    'Full — can push, create PRs': {
+      allow: ['git push', 'gh pr create'],
+      deny: ['gh pr merge'],
+    },
+    'Developer — can edit files, no push': {
+      deny: ['git push', 'gh pr'],
+    },
+    'Read-only — no edits, no push': {
+      deny: ['git push', 'gh pr', 'Edit', 'Write'],
+    },
+  };
+}
+
+export function getEditFields(): string[] {
+  if (currentLang === 'ko') {
+    return [
+      'name        — 표시 이름',
+      'character   — MBTI, 말투, 성격, 습관',
+      'role        — 범위, 권한, 전문성',
+      'engine      — 엔진 및 모델',
+      'budget      — 최대 예산',
+      'channels    — 채널 제한',
+      'permissions — 권한 프리셋',
+      'git         — Git 작성자 정보',
+      'all         — 전부 편집',
+    ];
+  }
+  return [
+    'name        — Display name',
+    'character   — MBTI, speech style, personality, habits',
+    'role        — Scope, authority, expertise',
+    'engine      — Engine and model',
+    'budget      — Max budget',
+    'channels    — Channel restrictions',
+    'permissions — Permission preset',
+    'git         — Git author identity',
+    'all         — Edit everything',
+  ];
+}
+
+/* ── Message dictionary ── */
+
+const msg: Record<string, Record<Lang, string>> = {
+  // language selection (shown before language is set, so bilingual)
+  'lang.prompt': { en: 'Use Korean? (한국어로 진행할까요?)', ko: '한국어로 진행할까요?' },
+
+  // init
+  'init.existing': { en: 'Existing workspace detected. Updating settings...\n', ko: '기존 워크스페이스 감지됨. 설정을 업데이트합니다...\n' },
+  'init.fresh': { en: 'Initializing workspace...\n', ko: '워크스페이스를 초기화합니다...\n' },
+  'init.askChannel': { en: 'Discord work channel ID (leave empty for all channels)', ko: 'Discord 작업 채널 ID (전체 채널이면 비워두세요)' },
+  'init.askHumanId': { en: 'Your Discord user ID (right-click your name → Copy User ID)', ko: 'Discord 사용자 ID (이름 우클릭 → 사용자 ID 복사)' },
+  'init.hooksWarn': { en: 'Warning: hooks/ not found in package. You may need to copy them manually.', ko: '경고: hooks/를 패키지에서 찾을 수 없습니다. 수동 복사가 필요할 수 있습니다.' },
+  'init.updated': { en: '\nWorkspace updated.', ko: '\n워크스페이스가 업데이트되었습니다.' },
+  'init.updatedTeams': { en: '  teams.json   — settings updated (assistants preserved)', ko: '  teams.json   — 설정 업데이트 (어시스턴트 유지)' },
+  'init.updatedEnv': { en: '  .env         — channel/port updated (tokens preserved)', ko: '  .env         — 채널/포트 업데이트 (토큰 유지)' },
+  'init.updatedHooks': { en: '  hooks/       — refreshed from package', ko: '  hooks/       — 패키지에서 갱신' },
+  'init.created': { en: '\nWorkspace created:', ko: '\n워크스페이스가 생성되었습니다:' },
+  'init.createdTeams': { en: '  teams.json   — assistant configuration', ko: '  teams.json   — 어시스턴트 설정' },
+  'init.createdEnv': { en: '  .env         — tokens and settings', ko: '  .env         — 토큰 및 설정' },
+  'init.createdPrompts': { en: '  prompts/     — personality files', ko: '  prompts/     — 성격 파일' },
+  'init.createdRepos': { en: '  repos/       — linked repositories', ko: '  repos/       — 연결된 저장소' },
+  'init.createdHooks': { en: '  hooks/       — Claude Code hooks', ko: '  hooks/       — Claude Code 훅' },
+  'init.next': { en: '\nNext: run `mococo add` to add your first assistant.', ko: '\n다음: `mococo add`를 실행하여 첫 어시스턴트를 추가하세요.' },
+
+  // add
+  'add.title': { en: 'Add a new agent\n', ko: '새 에이전트 추가\n' },
+  'add.identity': { en: '── Identity ──', ko: '── 신원 ──' },
+  'add.askId': { en: 'Assistant ID (lowercase, e.g. hr)', ko: '어시스턴트 ID (소문자, 예: hr)' },
+  'add.badId': { en: 'ID must be lowercase alphanumeric (start with letter).', ko: 'ID는 소문자 영숫자여야 합니다 (문자로 시작).' },
+  'add.dupId': { en: 'already exists.', ko: '이미 존재합니다.' },
+  'add.askName': { en: 'Display name (e.g. Backend)', ko: '표시 이름 (예: Backend)' },
+  'add.askLeader': { en: 'Is this the leader (responds to all messages)?', ko: '리더입니까 (모든 메시지에 응답)?' },
+  'add.character': { en: '\n── Character ──', ko: '\n── 캐릭터 ──' },
+  'add.askMbtiCustom': { en: 'MBTI (e.g. ISFJ — Diligent, caring, executor)', ko: 'MBTI (예: ISFJ — 성실, 배려, 실행가)' },
+  'add.speechCustom': { en: 'Enter speech style line by line (empty line to finish):', ko: '말투를 줄 단위로 입력하세요 (빈 줄로 종료):' },
+  'add.askTraits': { en: 'Personality traits (with behavior examples, comma-separated):', ko: '성격 특성 (행동 예시 포함, 쉼표 구분):' },
+  'add.traitsEx': { en: '  e.g. "Systematic — structures all requirements, Cautious — verifies when unsure"', ko: '  예: "체계적 — 모든 요구사항을 구조화, 신중함 — 불확실하면 검증"' },
+  'add.askHabits': { en: 'Habits (comma-separated):', ko: '습관 (쉼표 구분):' },
+  'add.habitsEx': { en: '  e.g. "Reports in conclusion→evidence→next-steps order"', ko: '  예: "결론→근거→다음 단계 순서로 보고"' },
+  'add.role': { en: '\n── Role ──', ko: '\n── 역할 ──' },
+  'add.askRole': { en: 'Core role (1-2 sentences)', ko: '핵심 역할 (1-2문장)' },
+  'add.askScope': { en: 'Scope (comma-separated):', ko: '담당 범위 (쉼표 구분):' },
+  'add.askNotScope': { en: 'Not in scope (comma-separated):', ko: '담당 아님 (쉼표 구분):' },
+  'add.askAuthIndep': { en: 'Independent decisions', ko: '독립 결정 권한' },
+  'add.askAuthApproval': { en: 'Needs approval for', ko: '승인 필요 사항' },
+  'add.askExpertise': { en: 'Expertise (comma-separated):', ko: '전문 분야 (쉼표 구분):' },
+  'add.askRules': { en: 'Additional rules (comma-separated):', ko: '추가 규칙 (쉼표 구분):' },
+  'add.askTeams': { en: 'Enable agent team mode (parallel sub-agents)?', ko: '에이전트 팀 모드 활성화 (병렬 서브 에이전트)?' },
+  'add.askTeamRules': { en: 'Team rules (comma-separated):', ko: '팀 규칙 (쉼표 구분):' },
+  'add.engine': { en: '\n── Engine ──', ko: '\n── 엔진 ──' },
+  'add.askModel': { en: 'Model', ko: '모델' },
+  'add.askBudget': { en: 'Max budget per invocation ($)', ko: '호출당 최대 예산 ($)' },
+  'add.tokens': { en: '\n── Tokens ──', ko: '\n── 토큰 ──' },
+  'add.askToken': { en: 'Discord bot token', ko: 'Discord 봇 토큰' },
+  'add.channels': { en: '\n── Channels ──', ko: '\n── 채널 ──' },
+  'add.askChannels': { en: 'Channel IDs this bot responds in (comma-separated, empty = all channels):', ko: '봇이 응답할 채널 ID (쉼표 구분, 비우면 전체 채널):' },
+  'add.permissions': { en: '\n── Permissions ──', ko: '\n── 권한 ──' },
+  'add.git': { en: '\n── Git identity ──', ko: '\n── Git 신원 ──' },
+  'add.askGitName': { en: 'Git author name', ko: 'Git 작성자 이름' },
+  'add.askGitEmail': { en: 'Git author email', ko: 'Git 작성자 이메일' },
+  'add.done': { en: 'added successfully.', ko: '추가 완료.' },
+  'add.configLine': { en: '  Config:  teams.json', ko: '  설정:    teams.json' },
+  'add.promptLine': { en: '  Prompt:', ko: '  프롬프트:' },
+  'add.tokenLine': { en: '  Tokens:  .env', ko: '  토큰:    .env' },
+  'add.launch': { en: '\nRun `mococo start` to launch.', ko: '\n`mococo start`로 실행하세요.' },
+
+  // edit
+  'edit.usage': { en: 'Usage: mococo edit <assistant-id>', ko: '사용법: mococo edit <어시스턴트-ID>' },
+  'edit.notFound': { en: 'not found.', ko: '을(를) 찾을 수 없습니다.' },
+  'edit.available': { en: 'Available:', ko: '사용 가능:' },
+  'edit.title': { en: 'Editing assistant', ko: '어시스턴트 편집 중' },
+  'edit.what': { en: 'What to edit:', ko: '편집할 항목:' },
+  'edit.regen': { en: 'Regenerate persona file? (overwrites existing)', ko: '성격 파일을 재생성하시겠습니까? (기존 파일 덮어쓰기)' },
+  'edit.regenDone': { en: '  Persona regenerated:', ko: '  성격 파일 재생성:' },
+  'edit.done': { en: 'updated successfully.', ko: '업데이트 완료.' },
+
+  // shared prompts used by both add & edit
+  'shared.mbti': { en: 'MBTI:', ko: 'MBTI:' },
+  'shared.speech': { en: 'Speech style:', ko: '말투:' },
+  'shared.traits': { en: '  Traits', ko: '  특성' },
+  'shared.habits': { en: '  Habits', ko: '  습관' },
+  'shared.scope': { en: '  Scope', ko: '  범위' },
+  'shared.notScope': { en: '  Not in scope', ko: '  담당 아님' },
+  'shared.expertise': { en: '  Expertise', ko: '  전문 분야' },
+  'shared.rules': { en: '  Rules', ko: '  규칙' },
+  'shared.teamRules': { en: '  Team rules', ko: '  팀 규칙' },
+  'shared.channels': { en: '  Channels', ko: '  채널' },
+  'shared.permPreset': { en: 'Permission preset:', ko: '권한 프리셋:' },
+  'shared.currentCh': { en: 'Current channels:', ko: '현재 채널:' },
+  'shared.allCh': { en: '(all channels)', ko: '(전체 채널)' },
+  'shared.chGuide': { en: 'Channel IDs (comma-separated, empty = all channels):', ko: '채널 ID (쉼표 구분, 비우면 전체 채널):' },
+  'shared.isLeader': { en: 'Is this the leader?', ko: '리더입니까?' },
+};
+
+export function t(key: string): string {
+  const entry = msg[key];
+  if (!entry) return key;
+  return entry[currentLang] ?? entry.en ?? key;
+}
+
+/**
+ * Parse --lang flag from argv and remove it from the array.
+ * Returns the remaining args.
+ */
+export function parseLangFlag(argv: string[]): string[] {
+  const args = [...argv];
+  const idx = args.indexOf('--lang');
+  if (idx !== -1 && args[idx + 1]) {
+    const val = args[idx + 1];
+    if (val === 'ko' || val === 'en') {
+      setLang(val, true);
+    }
+    args.splice(idx, 2);
+  }
+  return args;
+}

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -1,7 +1,10 @@
 #!/usr/bin/env node
 
-const command = process.argv[2];
-const arg = process.argv[3];
+import { parseLangFlag } from './i18n.js';
+
+const args = parseLangFlag(process.argv.slice(2));
+const command = args[0];
+const arg = args[1];
 
 async function main(): Promise<void> {
   switch (command) {
@@ -59,6 +62,9 @@ Usage:
   mococo restart           Trigger rebuild + restart (use with dev)
   mococo list              List configured assistants
   mococo remove <id>       Remove an assistant
+
+Options:
+  --lang <en|ko>           Set CLI language (init, add, edit)
 
 Getting started:
   mkdir my-team && cd my-team


### PR DESCRIPTION
## Summary
- CLI i18n 시스템 추가 (`--lang ko/en` 플래그 + 대화형 언어 선택)
- README.ko.md 전면 재작성 (영어 README와 동일 수준: 상세 커맨드 레퍼런스, 마법사 워크스루, 설정 레퍼런스, 사용 시나리오, 문제 해결)
- README.md 언어 플래그 문서화 및 상세 커맨드 예시 추가
- `.env.example`에 `GITHUB_TOKEN`/`GH_TOKEN` 추가

## Changes (8 files, +1480 / -279)
| File | Description |
|------|------------|
| `src/cli/i18n.ts` | 신규 — i18n 모듈 (메시지 사전, 언어 플래그 파싱, 프리셋 로컬라이제이션) |
| `src/cli/commands/add.ts` | i18n 적용 — 모든 프롬프트를 `t()` 함수로 교체 |
| `src/cli/commands/edit.ts` | i18n 적용 — 모든 프롬프트를 `t()` 함수로 교체 |
| `src/cli/commands/init.ts` | i18n 적용 — 언어 선택 + 모든 메시지 로컬라이제이션 |
| `src/cli/index.ts` | `--lang` 플래그 파싱 로직 추가 |
| `README.md` | 언어 플래그 문서 + 상세 커맨드 레퍼런스 강화 |
| `README.ko.md` | 전면 재작성 — 영어 버전과 동일 품질 |
| `.env.example` | GITHUB_TOKEN/GH_TOKEN 추가 |

## Test plan
- [ ] `mococo add --lang ko` — 한국어 프롬프트 출력 확인
- [ ] `mococo add --lang en` — 영어 프롬프트 출력 확인
- [ ] `mococo add` (플래그 없이) — 언어 선택 프롬프트 표시 확인
- [ ] `mococo init --lang ko` — 한국어 초기화 메시지 확인
- [ ] `tsc --noEmit` — 타입 체크 통과

🤖 Generated with [Claude Code](https://claude.com/claude-code)