### PR TITLE
chore. npm 배포 준비

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,0 +1,15 @@
+src/
+*.ts
+!dist/**/*.ts
+tsconfig.json
+.env
+.env.example
+.mococo/
+repos/
+prompts/
+teams.json
+*.log
+logs/
+.restart-trigger
+.gitignore
+nodemon.json

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2025 wodn5515
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -19,6 +19,14 @@ Assistant (bot): "On it. I'll create the auth routes and login form."
 npm install -g claude-mococo
 ```
 
+Or run directly without installing:
+
+```bash
+npx claude-mococo init
+npx claude-mococo add
+npx claude-mococo start
+```
+
 You also need at least one AI engine:
 
 ```bash
@@ -147,9 +155,10 @@ Or just run a single assistant. It's up to you.
 You can also set up manually by cloning the repo:
 
 ```bash
-git clone https://github.com/anthropics/claude-mococo.git
+git clone https://github.com/wodn5515/claude-mococo.git
 cd claude-mococo
 npm install
+npm run build
 ```
 
 Edit `teams.json` directly, create prompt files in `prompts/`, set tokens in `.env`, then `npm start`.

--- a/package.json
+++ b/package.json
@@ -3,18 +3,41 @@
   "version": "0.1.0",
   "description": "AI Team Company on Discord — multi-engine AI agents as distinct team identities",
   "type": "module",
+  "license": "MIT",
+  "author": "wodn5515",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/wodn5515/claude-mococo.git"
+  },
+  "homepage": "https://github.com/wodn5515/claude-mococo",
+  "keywords": [
+    "discord",
+    "bot",
+    "ai",
+    "claude",
+    "codex",
+    "gemini",
+    "assistant",
+    "team",
+    "agent"
+  ],
+  "engines": {
+    "node": ">=18.0.0"
+  },
   "bin": {
     "mococo": "dist/cli/index.js"
   },
   "files": [
     "dist/",
-    "hooks/"
+    "hooks/",
+    "defaults/"
   ],
   "scripts": {
     "start": "tsx src/index.ts",
     "dev": "nodemon --watch src --ext ts,json --exec 'npm run build && node dist/cli/index.js start'",
     "build": "tsc",
-    "typecheck": "tsc --noEmit"
+    "typecheck": "tsc --noEmit",
+    "prepublishOnly": "npm run build"
   },
   "dependencies": {
     "discord.js": "^14.16.0",


### PR DESCRIPTION
## Summary
- `package.json`에 npm 배포 메타데이터 추가 (`repository`, `keywords`, `homepage`, `author`, `engines`, `license`, `prepublishOnly`)
- `files` 배열에 `defaults/` 추가 (`mococo init` 시 `shared-rules.md` 복사에 필요)
- MIT `LICENSE` 파일 생성
- `.npmignore` 생성 (소스, 설정, 로그 파일 제외)
- README에 `npx` 설치 방법 추가 및 clone URL 수정

## npm 배포 절차 (머지 후)
1. `npm login` (npm 계정 로그인)
2. `npm publish` 실행
3. `npm install -g claude-mococo` 또는 `npx claude-mococo` 로 설치 검증

## 검증
- `tsc` 빌드 통과
- `npm pack --dry-run` 확인: 167 파일, 118.7kB (dist/, hooks/, defaults/, README, LICENSE 포함)

🤖 Generated with [Claude Code](https://claude.com/claude-code)