### PR TITLE
ci. GitHub Actions npm 자동 배포 워크플로우 추가

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -1,0 +1,26 @@
+name: Publish to npm
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'package.json'
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '18'
+          registry-url: 'https://registry.npmjs.org'
+
+      - run: npm ci
+
+      - run: npm run build
+
+      - run: npm publish --access public
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
## Summary
- PR #32에서 누락된 `.github/workflows/npm-publish.yml` 워크플로우 파일 추가
- `main` 브랜치에 push 시 `package.json` 변경이 있으면 npm 자동 배포 실행

## 변경 파일
- `.github/workflows/npm-publish.yml` (신규)

## 트리거 조건
- `main` push + `package.json` 변경 시

## 전제조건
- GitHub repo secrets에 `NPM_TOKEN` 등록 필요 (이미 완료)

🤖 Generated with [Claude Code](https://claude.com/claude-code)