### PR TITLE
fix. npm-publish 워크플로우 workflow_dispatch 트리거 추가

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -5,6 +5,7 @@ on:
     branches: [main]
     paths:
       - 'package.json'
+  workflow_dispatch:
 
 jobs:
   publish:


### PR DESCRIPTION
## Summary
- `npm-publish.yml`에 `workflow_dispatch` 이벤트 추가
- GitHub UI에서 수동 실행 가능 (package.json 변경 없이도 배포 트리거 가능)
- 기존 `push to main + paths: package.json` 자동 트리거는 유지

## Test plan
- [ ] PR 머지 후 GitHub Actions 탭에서 "Run workflow" 버튼 확인
- [ ] 수동 실행 시 npm publish 정상 동작 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)