### PR TITLE
fix. 리소스 누수 수정 — 클라이언트 미정리 및 타임아웃 리스너 누적

### DIFF
--- a/src/bot/client.ts
+++ b/src/bot/client.ts
@@ -373,6 +373,19 @@ export async function createBots(config: TeamsConfig, env: EnvConfig): Promise<v
       continue;
     }
 
+    // Destroy previous client instance to prevent resource leaks (listener accumulation, zombie WebSocket)
+    const existingClient = teamClients.get(team.id);
+    if (existingClient) {
+      console.log(`[${team.name}] Destroying previous client instance before recreation`);
+      existingClient.removeAllListeners();
+      try {
+        existingClient.destroy();
+      } catch (err) {
+        console.error(`[${team.name}] Failed to destroy old client:`, err);
+      }
+      teamClients.delete(team.id);
+    }
+
     const client = new Client({
       intents: [
         GatewayIntentBits.Guilds,

--- a/src/teams/invoker.ts
+++ b/src/teams/invoker.ts
@@ -32,35 +32,54 @@ export async function invokeTeam(
 
   // Track last known cost from engine messages so timeout can report actual spend
   let lastKnownCost = 0;
-  engine.on('message', (event) => {
+
+  // Named listeners for cleanup after resolve/timeout
+  const onMessage = (event: any) => {
     if (typeof event.total_cost_usd === 'number') {
       lastKnownCost = event.total_cost_usd;
     }
-  });
+  };
+
+  /** Remove all listeners attached by this invocation to prevent accumulation */
+  function cleanupListeners() {
+    engine.off('message', onMessage);
+    engine.off('result', onResult);
+    engine.off('exit', onExit);
+  }
+
+  let onResult: (event: any) => void;
+  let onExit: (code: number) => void;
+
+  engine.on('message', onMessage);
 
   const enginePromise = new Promise<InvocationResult>((resolve, reject) => {
     let resolved = false;
 
-    engine.on('result', (event) => {
+    onResult = (event) => {
       resolved = true;
       resolve({
         teamId: team.id,
         output: event.result ?? '',
         cost: event.total_cost_usd ?? 0,
       });
-    });
+    };
 
-    engine.on('exit', (code) => {
+    onExit = (code) => {
       if (!resolved) {
         reject(new Error(`Team ${team.id} (${team.engine}) exited with code ${code}`));
       }
-    });
+    };
+
+    engine.on('result', onResult);
+    engine.on('exit', onExit);
 
     engine.start().catch(reject);
   });
 
+  let timeoutId: ReturnType<typeof setTimeout>;
+
   const timeoutPromise = new Promise<InvocationResult>((resolve) => {
-    setTimeout(() => {
+    timeoutId = setTimeout(() => {
       engine.kill();
       console.warn(`[${team.id}] Timed out after ${INVOKE_TIMEOUT_MS / 1000}s (cost so far: $${lastKnownCost.toFixed(4)}) — returning partial result for continuation`);
       resolve({
@@ -72,5 +91,10 @@ export async function invokeTeam(
     }, INVOKE_TIMEOUT_MS);
   });
 
-  return Promise.race([enginePromise, timeoutPromise]);
+  try {
+    return await Promise.race([enginePromise, timeoutPromise]);
+  } finally {
+    clearTimeout(timeoutId!);
+    cleanupListeners();
+  }
 }


### PR DESCRIPTION
## Summary
- **client.ts**: `createBots()` 재호출 시 기존 Discord 클라이언트 `destroy()` + `removeAllListeners()` 추가. 이전 인스턴스가 정리되지 않아 WebSocket 연결 + 이벤트 리스너가 누적되던 문제 해결
- **invoker.ts**: `Promise.race` 완료 후 `finally` 블록에서 engine 리스너(`message`/`result`/`exit`) 제거 + 타임아웃 타이머 클리어. 타임아웃 빈번할수록 리스너가 누적되던 문제 해결

## 변경 사항

| 파일 | Before | After |
|------|--------|-------|
| `client.ts` | `teamClients.set()` 시 기존 클라이언트 무시 | 기존 클라이언트 `removeAllListeners()` → `destroy()` → `delete()` 후 재생성 |
| `invoker.ts` | 익명 리스너 + 타이머 미정리 | 네임드 리스너 + `finally` 블록에서 `engine.off()` + `clearTimeout()` |

## 영향도
- HIGH 2건 해결 (장기 실행 시 메모리 증가 방지)
- 기존 동작 변경 없음 — 정리 로직만 추가

## Test plan
- [ ] TypeScript 타입 체크 통과 확인
- [ ] 봇 재시작 시 기존 클라이언트 destroy 로그 확인
- [ ] 타임아웃 발생 후 리스너 수 증가하지 않는지 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)