### PR TITLE
fix. MEDIUM 리소스 누수 5건 정리

### DIFF
--- a/src/bot/improvement-scanner.ts
+++ b/src/bot/improvement-scanner.ts
@@ -595,12 +595,16 @@ function notifyLeaderOfNewIssues(
 // Main entry point -- start improvement scanner
 // ---------------------------------------------------------------------------
 
+let activeScanTimer: ReturnType<typeof setTimeout> | null = null;
+let scannerStopped = false;
+
 export function startImprovementScanner(
   config: TeamsConfig,
   triggerInvocation: InvocationTrigger,
   improvementChannelId?: string,
 ): void {
   console.log('[improvement-scanner] Started (interval: 30min, event-driven notify)');
+  scannerStopped = false;
 
   // Initialize previous issue keys from existing file
   const improvementPath = path.resolve(config.workspacePath, '.mococo/inbox/improvement.json');
@@ -636,7 +640,9 @@ export function startImprovementScanner(
 
   // Recursive setTimeout instead of setInterval to prevent overlapping
   function scheduleNextScan(): void {
-    setTimeout(() => {
+    if (scannerStopped) return;
+    activeScanTimer = setTimeout(() => {
+      activeScanTimer = null;
       runScanAndNotify()
         .catch(err => console.error(`[improvement-scanner] Unhandled error: ${err}`))
         .finally(() => scheduleNextScan());
@@ -644,9 +650,19 @@ export function startImprovementScanner(
   }
 
   // Run first scan after 2 minutes (let system settle), then schedule recurring
-  setTimeout(() => {
+  activeScanTimer = setTimeout(() => {
+    activeScanTimer = null;
     runScanAndNotify()
       .catch(err => console.error(`[improvement-scanner] Unhandled error: ${err}`))
       .finally(() => scheduleNextScan());
   }, 2 * 60_000);
+}
+
+export function stopImprovementScanner(): void {
+  scannerStopped = true;
+  if (activeScanTimer) {
+    clearTimeout(activeScanTimer);
+    activeScanTimer = null;
+  }
+  console.log('[improvement-scanner] Stopped');
 }

--- a/src/bot/inbox-compactor.ts
+++ b/src/bot/inbox-compactor.ts
@@ -636,13 +636,23 @@ async function pendingTaskLoop(
 // ---------------------------------------------------------------------------
 
 const activeTimers: ReturnType<typeof setInterval>[] = [];
+let inboxWatcher: fs.FSWatcher | null = null;
+let inboxDebounceTimer: NodeJS.Timeout | null = null;
 
 export function stopInboxCompactor(): void {
+  if (inboxWatcher) {
+    inboxWatcher.close();
+    inboxWatcher = null;
+  }
+  if (inboxDebounceTimer) {
+    clearTimeout(inboxDebounceTimer);
+    inboxDebounceTimer = null;
+  }
   for (const timer of activeTimers) {
     clearInterval(timer);
   }
   activeTimers.length = 0;
-  console.log('[inbox-compactor] Stopped all timers');
+  console.log('[inbox-compactor] Stopped all timers and watchers');
 }
 
 // ---------------------------------------------------------------------------
@@ -666,7 +676,6 @@ export function startInboxCompactor(
   const inboxDir = path.resolve(ws, '.mococo/inbox');
   fs.mkdirSync(inboxDir, { recursive: true });
 
-  let debounceTimer: NodeJS.Timeout | null = null;
   let pendingInboxInvoke = false;
 
   const executeHeartbeat = () => {
@@ -710,10 +719,10 @@ export function startInboxCompactor(
   };
 
   try {
-    fs.watch(inboxDir, (eventType, filename) => {
+    inboxWatcher = fs.watch(inboxDir, (eventType, filename) => {
       if (filename !== `${leaderTeam.id}.md`) return;
-      if (debounceTimer) clearTimeout(debounceTimer);
-      debounceTimer = setTimeout(() => {
+      if (inboxDebounceTimer) clearTimeout(inboxDebounceTimer);
+      inboxDebounceTimer = setTimeout(() => {
         immediateLeaderInvoke().catch(err => {
           console.error(`[inbox-compactor] Immediate invoke error: ${err}`);
         });

--- a/src/bot/memory-consolidator.ts
+++ b/src/bot/memory-consolidator.ts
@@ -258,10 +258,20 @@ function checkMemories(config: TeamsConfig): void {
   }
 }
 
+let delayTimer: ReturnType<typeof setTimeout> | null = null;
+let intervalTimer: ReturnType<typeof setInterval> | null = null;
+
 export function startMemoryConsolidator(config: TeamsConfig): void {
   console.log('[memory-consolidator] Started (interval: 6h)');
-  setTimeout(() => {
+  delayTimer = setTimeout(() => {
+    delayTimer = null;
     checkMemories(config);
-    setInterval(() => checkMemories(config), CONSOLIDATE_INTERVAL_MS);
+    intervalTimer = setInterval(() => checkMemories(config), CONSOLIDATE_INTERVAL_MS);
   }, 60_000);
+}
+
+export function stopMemoryConsolidator(): void {
+  if (delayTimer) { clearTimeout(delayTimer); delayTimer = null; }
+  if (intervalTimer) { clearInterval(intervalTimer); intervalTimer = null; }
+  console.log('[memory-consolidator] Stopped');
 }

--- a/src/orchestrator/claude-engine.ts
+++ b/src/orchestrator/claude-engine.ts
@@ -77,6 +77,7 @@ export class ClaudeEngine extends BaseEngine {
 
     this.proc.on('error', (err) => {
       console.error(`[claude:${this.opts.teamId}] spawn error: ${err.message}`);
+      stderrRl.close();
       if (!procExited) {
         exitCode = 1;
         procExited = true;
@@ -87,6 +88,7 @@ export class ClaudeEngine extends BaseEngine {
 
     this.proc.on('exit', (code) => {
       console.log(`[claude:${this.opts.teamId}] exited with code ${code}`);
+      stderrRl.close();
       exitCode = code;
       procExited = true;
       maybeEmitExit();

--- a/src/orchestrator/codex-engine.ts
+++ b/src/orchestrator/codex-engine.ts
@@ -61,11 +61,15 @@ export class CodexEngine extends BaseEngine {
 
     this.proc.on('error', (err) => {
       this.clearTimers();
+      stdoutRl.close();
+      stderrRl.close();
       console.error(`[codex:${this.opts.teamId}] spawn error: ${err.message}`);
     });
 
     this.proc.on('exit', (code) => {
       this.clearTimers();
+      stdoutRl.close();
+      stderrRl.close();
       const output = messages.join('\n').trim();
       console.log(`[codex:${this.opts.teamId}] exited with code ${code} (output: ${output.length} chars)`);
       this.emit('result', { type: 'result', result: output, total_cost_usd: 0 });

--- a/src/server/hook-receiver.ts
+++ b/src/server/hook-receiver.ts
@@ -6,6 +6,16 @@ export const hookEvents = new EventEmitter();
 
 const MAX_BODY_SIZE = 1024 * 1024; // 1MB limit
 
+let activeServer: http.Server | null = null;
+
+export function stopHookServer(): void {
+  if (activeServer) {
+    activeServer.close();
+    activeServer = null;
+    console.log('[hook-receiver] Server stopped');
+  }
+}
+
 export function startHookServer(port: number) {
   const server = http.createServer((req, res) => {
     if (req.method !== 'POST' || req.url !== '/hook') {
@@ -54,5 +64,6 @@ export function startHookServer(port: number) {
     console.log(`Hook receiver listening on :${port}`);
   });
 
+  activeServer = server;
   return server;
 }


### PR DESCRIPTION
## Summary
- `inbox-compactor.ts`: `fs.watch()` 워처 + debounce 타이머를 모듈 변수에 저장, `stopInboxCompactor()`에서 정리
- `memory-consolidator.ts`: `setInterval`/`setTimeout` ID 저장 + `stopMemoryConsolidator()` 추가
- `improvement-scanner.ts`: 재귀 `setTimeout` ID 추적 + `scannerStopped` 플래그로 정지 제어 + `stopImprovementScanner()` 추가
- `claude-engine.ts`: stderr `readline` 인터페이스를 프로세스 `exit`/`error` 시 `close()` 호출
- `codex-engine.ts`: stdout/stderr `readline` 인터페이스를 프로세스 `exit`/`error` 시 `close()` 호출
- `hook-receiver.ts`: `activeServer` 변수에 서버 인스턴스 저장 + `stopHookServer()` 추가

## Context
HIGH 2건 (PR #38)에 이어 MEDIUM 5건 리소스 누수 정리. 장기 실행 봇 특성상 타이머/워처/readline 미정리가 점진적 메모리 증가로 이어질 수 있음.

## Test plan
- [ ] `npx tsc --noEmit` 타입 체크 통과 확인
- [ ] 봇 시작 후 각 모듈 로그에서 정상 초기화 확인
- [ ] graceful shutdown 시 "Stopped" 로그 출력 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)