### PR TITLE
feat. Hourly heartbeat 스케줄링 구현

### DIFF
--- a/src/bot/__tests__/heartbeat-periodic.test.ts
+++ b/src/bot/__tests__/heartbeat-periodic.test.ts
@@ -101,6 +101,47 @@ describe('parseHeartbeatMd', () => {
     expect(tasks[0].assignee).toBeNull();
   });
 
+  it('parses hourly tasks', () => {
+    fs.writeFileSync(path.join(tmpDir, 'heartbeat.md'), `
+## Hourly
+- [ ] 코드 분석 @체커코코
+- [ ] 이슈 관리 @대장코코
+`);
+
+    const tasks = parseHeartbeatMd(tmpDir);
+    expect(tasks).toHaveLength(2);
+    expect(tasks[0]).toEqual({
+      section: 'hourly',
+      content: '코드 분석',
+      assignee: '체커코코',
+    });
+    expect(tasks[1]).toEqual({
+      section: 'hourly',
+      content: '이슈 관리',
+      assignee: '대장코코',
+    });
+  });
+
+  it('parses all section types together', () => {
+    fs.writeFileSync(path.join(tmpDir, 'heartbeat.md'), `
+## Daily
+- [ ] 일일 작업
+
+## Weekly
+- [ ] 주간 작업
+
+## Hourly
+- [ ] 시간별 작업
+
+## Periodic
+- [ ] 상시 작업
+`);
+
+    const tasks = parseHeartbeatMd(tmpDir);
+    expect(tasks).toHaveLength(4);
+    expect(tasks.map(t => t.section)).toEqual(['daily', 'weekly', 'hourly', 'periodic']);
+  });
+
   it('returns empty when file does not exist', () => {
     const tasks = parseHeartbeatMd(path.join(tmpDir, 'nonexistent'));
     expect(tasks).toEqual([]);
@@ -118,12 +159,12 @@ describe('getDueHeartbeatTasks — periodic occupied filter', () => {
     vi.mocked(isBusy).mockReturnValue(false);
     vi.mocked(isQueued).mockReturnValue(false);
 
-    // Write heartbeat state to avoid daily/weekly tasks triggering
+    // Write heartbeat state to avoid daily/weekly/hourly tasks triggering
     const mocoDir = path.join(tmpDir, '.mococo');
     fs.mkdirSync(mocoDir, { recursive: true });
     fs.writeFileSync(
       path.join(mocoDir, 'heartbeat-state.json'),
-      JSON.stringify({ lastDaily: new Date().toISOString(), lastWeekly: new Date().toISOString() }),
+      JSON.stringify({ lastDaily: new Date().toISOString(), lastWeekly: new Date().toISOString(), lastHourly: new Date().toISOString() }),
     );
   });
 
@@ -208,5 +249,102 @@ describe('getDueHeartbeatTasks — periodic occupied filter', () => {
     // No config passed — should not filter
     const tasks = getDueHeartbeatTasks(tmpDir);
     expect(tasks).toHaveLength(2);
+  });
+});
+
+describe('getDueHeartbeatTasks — hourly scheduling', () => {
+  let tmpDir: string;
+
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'heartbeat-hourly-'));
+    vi.mocked(isBusy).mockReturnValue(false);
+    vi.mocked(isQueued).mockReturnValue(false);
+  });
+
+  afterEach(() => {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+    vi.restoreAllMocks();
+  });
+
+  function writeState(dir: string, state: { lastDaily?: string; lastWeekly?: string; lastHourly?: string | null }) {
+    const mocoDir = path.join(dir, '.mococo');
+    fs.mkdirSync(mocoDir, { recursive: true });
+    fs.writeFileSync(
+      path.join(mocoDir, 'heartbeat-state.json'),
+      JSON.stringify({
+        lastDaily: state.lastDaily ?? new Date().toISOString(),
+        lastWeekly: state.lastWeekly ?? new Date().toISOString(),
+        lastHourly: state.lastHourly ?? null,
+      }),
+    );
+  }
+
+  function writeHourlyHeartbeat(dir: string) {
+    fs.writeFileSync(path.join(dir, 'heartbeat.md'), `
+## Hourly
+- [ ] 코드 분석 @체커코코
+- [ ] 이슈 관리 @대장코코
+`);
+  }
+
+  it('includes hourly tasks when lastHourly is null (never run)', () => {
+    writeHourlyHeartbeat(tmpDir);
+    writeState(tmpDir, { lastHourly: null });
+
+    const tasks = getDueHeartbeatTasks(tmpDir);
+    const hourlyTasks = tasks.filter(t => t.section === 'hourly');
+    expect(hourlyTasks).toHaveLength(2);
+  });
+
+  it('includes hourly tasks when last run was in a previous hour', () => {
+    writeHourlyHeartbeat(tmpDir);
+    // Set lastHourly to 2 hours ago
+    const twoHoursAgo = new Date(Date.now() - 2 * 60 * 60_000).toISOString();
+    writeState(tmpDir, { lastHourly: twoHoursAgo });
+
+    const tasks = getDueHeartbeatTasks(tmpDir);
+    const hourlyTasks = tasks.filter(t => t.section === 'hourly');
+    expect(hourlyTasks).toHaveLength(2);
+  });
+
+  it('excludes hourly tasks when already run this hour', () => {
+    writeHourlyHeartbeat(tmpDir);
+    // Set lastHourly to current time (same hour)
+    writeState(tmpDir, { lastHourly: new Date().toISOString() });
+
+    const tasks = getDueHeartbeatTasks(tmpDir);
+    const hourlyTasks = tasks.filter(t => t.section === 'hourly');
+    expect(hourlyTasks).toHaveLength(0);
+  });
+
+  it('includes hourly tasks at hour boundary', () => {
+    writeHourlyHeartbeat(tmpDir);
+    // Set lastHourly to 59 minutes ago — if that crosses the hour boundary, it should be due
+    const now = new Date();
+    const lastHour = new Date(now);
+    lastHour.setHours(lastHour.getHours() - 1);
+    writeState(tmpDir, { lastHourly: lastHour.toISOString() });
+
+    const tasks = getDueHeartbeatTasks(tmpDir);
+    const hourlyTasks = tasks.filter(t => t.section === 'hourly');
+    expect(hourlyTasks).toHaveLength(2);
+  });
+
+  it('handles mixed sections with hourly correctly', () => {
+    fs.writeFileSync(path.join(tmpDir, 'heartbeat.md'), `
+## Periodic
+- [ ] 상시 모니터링
+
+## Hourly
+- [ ] 시간별 작업
+
+## Daily
+- [ ] 일일 작업
+`);
+    // daily+hourly not run, weekly already run
+    writeState(tmpDir, { lastHourly: null, lastDaily: '2020-01-01T00:00:00Z', lastWeekly: new Date().toISOString() });
+
+    const tasks = getDueHeartbeatTasks(tmpDir);
+    expect(tasks.map(t => t.section).sort()).toEqual(['daily', 'hourly', 'periodic']);
   });
 });

--- a/src/bot/inbox-compactor.ts
+++ b/src/bot/inbox-compactor.ts
@@ -29,7 +29,7 @@ const PENDING_TASK_COOLDOWN_MS = 2 * 60 * 60_000; // 2 hours cooldown per team
 // ---------------------------------------------------------------------------
 
 export interface HeartbeatTask {
-  section: 'daily' | 'weekly' | 'periodic' | 'on-demand';
+  section: 'daily' | 'weekly' | 'hourly' | 'periodic' | 'on-demand';
   content: string;
   assignee: string | null;
 }
@@ -37,6 +37,7 @@ export interface HeartbeatTask {
 interface HeartbeatState {
   lastDaily: string | null;
   lastWeekly: string | null;
+  lastHourly: string | null;
 }
 
 export function parseHeartbeatMd(ws: string): HeartbeatTask[] {
@@ -48,10 +49,10 @@ export function parseHeartbeatMd(ws: string): HeartbeatTask[] {
   let currentSection: HeartbeatTask['section'] | null = null;
 
   for (const line of content.split('\n')) {
-    const sectionMatch = line.match(/^##\s+(Daily|Weekly|Periodic|On-demand)/i);
+    const sectionMatch = line.match(/^##\s+(Daily|Weekly|Hourly|Periodic|On-demand)/i);
     if (sectionMatch) {
       const s = sectionMatch[1].toLowerCase() as HeartbeatTask['section'];
-      if (['daily', 'weekly', 'periodic', 'on-demand'].includes(s)) {
+      if (['daily', 'weekly', 'hourly', 'periodic', 'on-demand'].includes(s)) {
         currentSection = s;
       }
       continue;
@@ -78,7 +79,7 @@ function readHeartbeatState(ws: string): HeartbeatState {
   try {
     return JSON.parse(fs.readFileSync(statePath, 'utf-8'));
   } catch {
-    return { lastDaily: null, lastWeekly: null };
+    return { lastDaily: null, lastWeekly: null, lastHourly: null };
   }
 }
 
@@ -103,6 +104,7 @@ export function getDueHeartbeatTasks(ws: string, config?: TeamsConfig): Heartbea
   const due: HeartbeatTask[] = [];
   let dailyDue = false;
   let weeklyDue = false;
+  let hourlyDue = false;
 
   // Check daily: due if not run today
   if (!state.lastDaily || !state.lastDaily.startsWith(todayStr)) {
@@ -116,6 +118,12 @@ export function getDueHeartbeatTasks(ws: string, config?: TeamsConfig): Heartbea
   const mondayStr = monday.toISOString().slice(0, 10);
   if (!state.lastWeekly || state.lastWeekly.slice(0, 10) < mondayStr) {
     weeklyDue = true;
+  }
+  // Check hourly: due if not run in the current hour
+  // Compare YYYY-MM-DDTHH prefix to detect hour boundary
+  const currentHourPrefix = now.toISOString().slice(0, 13); // "YYYY-MM-DDTHH"
+  if (!state.lastHourly || !state.lastHourly.startsWith(currentHourPrefix)) {
+    hourlyDue = true;
   }
 
   for (const task of allTasks) {
@@ -133,6 +141,7 @@ export function getDueHeartbeatTasks(ws: string, config?: TeamsConfig): Heartbea
         break;
       case 'daily': if (dailyDue) due.push(task); break;
       case 'weekly': if (weeklyDue) due.push(task); break;
+      case 'hourly': if (hourlyDue) due.push(task); break;
       // on-demand: excluded from automatic heartbeat — requires explicit trigger
     }
   }
@@ -396,15 +405,17 @@ async function leaderHeartbeat(
     lastHeartbeatFingerprint = heartbeatFp;
     lastHeartbeatInvokeAt = Date.now();
 
-    // Update heartbeat.md state tracking (mark daily/weekly as executed)
+    // Update heartbeat.md state tracking (mark daily/weekly/hourly as executed)
     if (dueHeartbeatTasks.length > 0) {
       const hasDaily = dueHeartbeatTasks.some(t => t.section === 'daily');
       const hasWeekly = dueHeartbeatTasks.some(t => t.section === 'weekly');
-      if (hasDaily || hasWeekly) {
+      const hasHourly = dueHeartbeatTasks.some(t => t.section === 'hourly');
+      if (hasDaily || hasWeekly || hasHourly) {
         const state = readHeartbeatState(ws);
         const nowIso = new Date().toISOString();
         if (hasDaily) state.lastDaily = nowIso;
         if (hasWeekly) state.lastWeekly = nowIso;
+        if (hasHourly) state.lastHourly = nowIso;
         writeHeartbeatState(ws, state);
       }
     }


### PR DESCRIPTION
## Summary
- `inbox-compactor.ts`에서 `heartbeat.md`의 `## Hourly` 섹션을 인식하지 못하던 문제 수정
- 6곳 누락 코드 추가: 타입 정의, 파싱 정규식, 상태 인터페이스(`lastHourly`), 판정 로직(시간 단위 비교), switch 분기, 상태 갱신
- 테스트 17개 전부 PASS (기존 10개 + 신규 hourly 7개)

## 변경 파일
- `src/bot/inbox-compactor.ts` — hourly 로직 6곳 추가
- `src/bot/__tests__/heartbeat-periodic.test.ts` — hourly 파싱/스케줄링 테스트 추가

## Test plan
- [x] 기존 periodic/daily/weekly 테스트 통과 확인
- [x] hourly 파싱 테스트 — `## Hourly` 섹션이 올바르게 파싱됨
- [x] hourly 스케줄링 테스트 — lastHourly null/이전 시간/현재 시간 각 케이스 검증
- [x] 혼합 섹션 테스트 — daily+hourly+periodic 동시 동작 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)