### PR TITLE
fix. heartbeat false alarm + hourly 트리거 누락 수정 + 0.5.0 버전업

### DIFF
--- a/src/bot/inbox-compactor.ts
+++ b/src/bot/inbox-compactor.ts
@@ -253,7 +253,7 @@ ${heartbeatReport || '(none)'}
 - Unresolved dispatches (5min+) → INVOKE
 - High severity improvement issues → INVOKE (include issue details in reason)
 - Medium/low only improvement issues → NO (다음 정기 리뷰에서 처리)
-- Heartbeat tasks (periodic/daily/weekly) → INVOKE (include task summary in reason)
+- Heartbeat tasks (periodic/daily/weekly/hourly) → INVOKE (include task summary in reason)
 - Empty inbox + no unresolved + no high issues + no heartbeat tasks → NO
 
 Output ONE line:
@@ -415,6 +415,22 @@ async function leaderHeartbeat(
     // Update heartbeat dedup state
     lastHeartbeatFingerprint = heartbeatFp;
     lastHeartbeatInvokeAt = Date.now();
+
+    // Clear improvement.json after consuming — prevent same issues from re-triggering
+    // The leader already received the report in the triage prompt.
+    // The improvement-scanner will write fresh issues on its next scan cycle.
+    if (improvementReport) {
+      try {
+        const improvementPath = path.resolve(ws, '.mococo/inbox/improvement.json');
+        const raw = fs.readFileSync(improvementPath, 'utf-8');
+        const data = JSON.parse(raw);
+        data.issues = [];
+        atomicWriteSync(improvementPath, JSON.stringify(data, null, 2));
+        console.log('[heartbeat] Cleared improvement.json issues after leader invoke');
+      } catch {
+        // File may not exist or be malformed — ignore
+      }
+    }
 
     // Update heartbeat.md state tracking (mark daily/weekly/periodic/hourly as executed)
     if (dueHeartbeatTasks.length > 0) {


### PR DESCRIPTION
## Summary
- **false alarm 수정**: `leaderHeartbeat()`에서 improvement.json을 소비한 후 issues를 초기화 (`data.issues = []`). 동일 이슈가 매 3분마다 반복 보고되던 문제 해결
- **hourly 트리거 수정**: Haiku triage 룰에 `hourly` 추가. 기존 `periodic/daily/weekly`만 명시되어 hourly 작업이 INVOKE 트리거에서 누락되던 문제 해결
- **버전업**: 0.4.0 → 0.5.0

## Root Cause — Hourly 미실행 원인 분석

0.4.0(PR #45)에서 hourly heartbeat 기능 자체는 완벽하게 구현됨:
- `parseHeartbeatMd()`: `## Hourly` 섹션 파싱 ✅
- `HeartbeatState.lastHourly`: 상태 관리 ✅
- `getDueHeartbeatTasks()`: 시간 경계 판정 ✅
- 상태 업데이트 로직 ✅

**그러나 triage 규칙에 "hourly"가 누락됨:**

```
// 수정 전 (0.4.0)
- Heartbeat tasks (periodic/daily/weekly) → INVOKE

// 수정 후 (0.5.0)
- Heartbeat tasks (periodic/daily/weekly/hourly) → INVOKE
```

Haiku triage 모델이 hourly 작업을 인식하지 못해 NO를 반환 → 리더 invoke 미발생 → hourly 작업 실행 안 됨.

## Changes
- `inbox-compactor.ts:256`: triage 룰에 `hourly` 추가
- `inbox-compactor.ts:419-433`: invoke 후 improvement.json issues 초기화 로직 추가
- `package.json`: 0.4.0 → 0.5.0 버전업

## Test plan
- [x] 기존 heartbeat-periodic 테스트 22개 전부 통과
- [x] 체커코코 코드리뷰 PASS

🤖 Generated with [Claude Code](https://claude.com/claude-code)