### PR TITLE
chore. bump version 0.4.0 → 0.5.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "claude-mococo",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "description": "AI Team Company on Discord — multi-engine AI agents as distinct team identities",
   "type": "module",
   "license": "MIT",


### PR DESCRIPTION
## Summary
- PR #57 머지 시 누락된 `package.json` 버전업 반영 (0.4.0 → 0.5.0)
- 이 PR 머지 시 `npm-publish.yml` 워크플로우가 자동 트리거됨 (`paths: ['package.json']`)

## Test plan
- [ ] `package.json` version 필드가 `0.5.0`으로 변경되었는지 확인
- [ ] 머지 후 GitHub Actions `npm-publish` 워크플로우 자동 실행 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)