### PR TITLE
fix. heartbeat 자동 실행 안정성 개선

### DIFF
--- a/src/bot/__tests__/heartbeat-periodic.test.ts
+++ b/src/bot/__tests__/heartbeat-periodic.test.ts
@@ -297,11 +297,11 @@ describe('getDueHeartbeatTasks — periodic cooldown', () => {
     expect(periodicTasks).toHaveLength(2);
   });
 
-  it('excludes periodic tasks when within cooldown period (30min)', () => {
+  it('excludes periodic tasks when within cooldown period (3min)', () => {
     writePeriodicHeartbeat(tmpDir);
-    // Set lastPeriodic to 5 minutes ago — within 30min cooldown
-    const fiveMinAgo = new Date(Date.now() - 5 * 60_000).toISOString();
-    writeState(tmpDir, { lastPeriodic: fiveMinAgo });
+    // Set lastPeriodic to 1 minute ago — within 3min cooldown
+    const oneMinAgo = new Date(Date.now() - 1 * 60_000).toISOString();
+    writeState(tmpDir, { lastPeriodic: oneMinAgo });
 
     const tasks = getDueHeartbeatTasks(tmpDir);
     const periodicTasks = tasks.filter(t => t.section === 'periodic');
@@ -310,9 +310,9 @@ describe('getDueHeartbeatTasks — periodic cooldown', () => {
 
   it('includes periodic tasks when cooldown expired', () => {
     writePeriodicHeartbeat(tmpDir);
-    // Set lastPeriodic to 31 minutes ago — cooldown expired
-    const thirtyOneMinAgo = new Date(Date.now() - 31 * 60_000).toISOString();
-    writeState(tmpDir, { lastPeriodic: thirtyOneMinAgo });
+    // Set lastPeriodic to 4 minutes ago — cooldown expired (3min cooldown)
+    const fourMinAgo = new Date(Date.now() - 4 * 60_000).toISOString();
+    writeState(tmpDir, { lastPeriodic: fourMinAgo });
 
     const tasks = getDueHeartbeatTasks(tmpDir);
     const periodicTasks = tasks.filter(t => t.section === 'periodic');

--- a/src/bot/inbox-compactor.ts
+++ b/src/bot/inbox-compactor.ts
@@ -23,7 +23,7 @@ const HEARTBEAT_MS = 3 * 60_000;        // 3 minutes
 const FOLLOW_UP_MS = 2 * 60_000;         // 2 minutes
 const DAILY_DIGEST_MS = 24 * 60 * 60_000; // 24 hours
 const PENDING_TASK_COOLDOWN_MS = 2 * 60 * 60_000; // 2 hours cooldown per team
-const PERIODIC_COOLDOWN_MS = 30 * 60_000;          // 30 minutes — periodic tasks cooldown
+const PERIODIC_COOLDOWN_MS = 3 * 60_000;            // 3 minutes — match heartbeat.md spec
 
 // ---------------------------------------------------------------------------
 // Heartbeat.md — scheduled tasks from file
@@ -383,17 +383,36 @@ async function leaderHeartbeat(
       return;
     }
 
-    // Haiku triage
+    // Haiku triage — with fallback for heartbeat tasks
     const triagePrompt = buildTriagePrompt(inbox, unresolved.length, improvementReport, heartbeatReport);
-    const triageResult = await runHaiku(triagePrompt);
+    let reason: string;
+    try {
+      const triageResult = await runHaiku(triagePrompt);
 
-    if (triageResult.startsWith('NO')) {
-      console.log('[heartbeat] Haiku triage: no leader intervention needed');
-      return;
+      if (triageResult.startsWith('NO')) {
+        // Fallback: if heartbeat tasks are due, force invoke even if Haiku says NO
+        if (dueHeartbeatTasks.length > 0) {
+          console.log(`[heartbeat] Haiku said NO but ${dueHeartbeatTasks.length} heartbeat task(s) due — forcing invoke`);
+          reason = `정기 작업 ${dueHeartbeatTasks.length}건 실행 예정`;
+        } else {
+          console.log('[heartbeat] Haiku triage: no leader intervention needed');
+          return;
+        }
+      } else {
+        reason = triageResult.replace(/^INVOKE:\s*/, '').trim() || 'inbox 확인 필요';
+      }
+    } catch (triageErr) {
+      // Haiku failure fallback: if heartbeat tasks or inbox exist, invoke anyway
+      if (dueHeartbeatTasks.length > 0 || inbox) {
+        console.warn(`[heartbeat] Haiku triage failed, falling back to direct invoke: ${triageErr}`);
+        reason = dueHeartbeatTasks.length > 0
+          ? `정기 작업 ${dueHeartbeatTasks.length}건 실행 예정 (triage 실패 fallback)`
+          : 'inbox 확인 필요 (triage 실패 fallback)';
+      } else {
+        console.warn(`[heartbeat] Haiku triage failed, nothing actionable to invoke for: ${triageErr}`);
+        return;
+      }
     }
-
-    // Extract reason from "INVOKE: reason"
-    const reason = triageResult.replace(/^INVOKE:\s*/, '').trim() || 'inbox 확인 필요';
 
     console.log(`[heartbeat] Invoking leader: ${reason}`);
 
@@ -478,8 +497,8 @@ async function followUpLoop(
     // Still working → wait
     if (isBusy(team.id)) continue;
 
-    // Just finished → give it a moment
-    if (elapsedMin < 5) continue;
+    // Just finished → give it a moment (10 min grace period)
+    if (elapsedMin < 10) continue;
 
     // Already queued → don't pile on
     if (isQueued(team.id)) continue;
@@ -496,11 +515,11 @@ async function followUpLoop(
       continue;
     }
 
-    if (elapsedMin < 15) {
+    if (elapsedMin < 30) {
       // triggerInvocation 직전 최종 상태 체크 (race condition 방지)
       if (isOccupied(team.id)) continue;
 
-      // 5-15 min: nudge the team to report
+      // 10-30 min: nudge the team to report
       console.log(`[follow-up] Nudging ${team.name} to report (${Math.round(elapsedMin)}min since dispatch, nudge ${currentNudges + 1}/${MAX_NUDGES_PER_RECORD})`);
       const nudgeMsg: ConversationMessage = {
         teamId: 'system',
@@ -519,32 +538,11 @@ async function followUpLoop(
       setFollowUpCooldown(team.id);
       break; // One nudge per cycle
     } else {
-      // 15min+: notify leader ONCE, then auto-resolve to prevent infinite loop
-      const leader = Object.values(config.teams).find(t => t.isLeader);
-      // triggerInvocation 직전 최종 상태 체크 (race condition 방지)
-      if (leader && !isOccupied(leader.id)) {
-        console.log(`[follow-up] Alerting leader: ${team.name} unreported for ${Math.round(elapsedMin)}min (auto-resolving after alert)`);
-        const alertMsg: ConversationMessage = {
-          teamId: 'system',
-          teamName: 'System',
-          content: `[미보고 알림] ${team.name}가 ${Math.round(elapsedMin)}분째 보고하지 않음. 작업: ${record.reason}`,
-          timestamp: new Date(),
-          mentions: [leader.id],
-        };
-        const alertChannelId = env.workChannelId || env.memberTrackingChannelId;
-        if (alertChannelId) {
-          addMessage(alertChannelId, alertMsg);
-          if (isOccupied(leader.id)) {
-            console.log(`[follow-up] Leader became occupied during alert, skipping invocation`);
-          } else {
-            triggerInvocation(leader, alertMsg, alertChannelId, config, env, newChain());
-          }
-        }
-      }
-      // Auto-resolve after leader alert to prevent repeated notifications
+      // 30min+: auto-resolve silently — no leader alert to prevent false alarms
+      // The leader will see unresolved dispatches in the next heartbeat triage if needed
       ledger.resolveById(record.id);
       nudgeCounts.delete(record.id);
-      console.log(`[follow-up] Auto-resolved record for ${team.name} after leader alert (${Math.round(elapsedMin)}min elapsed)`);
+      console.log(`[follow-up] Auto-resolved record for ${team.name} after ${Math.round(elapsedMin)}min (silent — no leader alert)`);
     }
   }
 }


### PR DESCRIPTION
## Summary
- `PERIODIC_COOLDOWN_MS` 30분 → 3분으로 변경 (heartbeat.md 명세 일치)
- Haiku triage가 NO 반환하거나 실패해도 heartbeat 작업이 due면 강제 INVOKE fallback 처리
- followUpLoop 미보고 알림 임계값 강화: 넛지 구간 5→10분, 리더 알림 15→30분
- 30분 초과 미보고 시 리더에게 알림 대신 자동 해소 (false alarm 방지)

## 원인 분석
1. **heartbeat 미동작**: Haiku triage가 `NO` 반환 시 heartbeat.md 작업이 있어도 스킵됨. 사람이 메시지 보낼 때만 `messageCreate`로 직접 호출되어 동작하는 것처럼 보였음.
2. **쿨다운 불일치**: heartbeat.md에 "매 3분"이라고 명시되어 있으나 코드상 `PERIODIC_COOLDOWN_MS = 30분`이어서 periodic 작업이 30분에 한 번만 due 판정
3. **false alarm 남발**: followUpLoop이 15분만에 리더에게 `[미보고 알림]` 발송 → 리더가 "False Alarm" 반복

## Test plan
- [x] 기존 테스트 22건 전부 통과 (쿨다운 테스트값 3분 기준으로 업데이트)
- [x] 타입체크 통과
- [x] 빌드 성공

🤖 Generated with [Claude Code](https://claude.com/claude-code)