### PR TITLE
feat: HTTP MCP 서버 타입 지원 추가

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -38,31 +38,56 @@ export function loadTeamsConfig(workspacePath: string = process.cwd()): TeamsCon
       console.warn(`[config] Missing env var ${discordTokenEnv} for team "${id}" — bot will not start`);
     }
 
-    // Resolve MCP server configs: expand $VAR references in env values
+    // Resolve MCP server configs: expand $VAR references in env/header values
     let mcpServers: Record<string, McpServerConfig> | undefined;
     if (cfg.mcpServers) {
       mcpServers = {};
       for (const [name, server] of Object.entries(cfg.mcpServers as Record<string, any>)) {
-        const resolvedEnv: Record<string, string> = {};
-        if (server.env) {
-          for (const [key, val] of Object.entries(server.env as Record<string, string>)) {
-            if (val.startsWith('$')) {
-              const envName = val.slice(1);
-              const envValue = process.env[envName];
-              if (envValue === undefined) {
-                console.warn(`[config] MCP server "${name}" for team "${id}": env var ${envName} is not set (key: ${key})`);
+        if (server.type === 'http') {
+          // HTTP MCP server — resolve $VAR in headers
+          const resolvedHeaders: Record<string, string> = {};
+          if (server.headers) {
+            for (const [key, val] of Object.entries(server.headers as Record<string, string>)) {
+              if (val.startsWith('$')) {
+                const envName = val.slice(1);
+                const envValue = process.env[envName];
+                if (envValue === undefined) {
+                  console.warn(`[config] MCP server "${name}" for team "${id}": env var ${envName} is not set (header: ${key})`);
+                }
+                resolvedHeaders[key] = envValue ?? '';
+              } else {
+                resolvedHeaders[key] = val;
               }
-              resolvedEnv[key] = envValue ?? '';
-            } else {
-              resolvedEnv[key] = val;
             }
           }
+          mcpServers[name] = {
+            type: 'http',
+            url: server.url,
+            headers: Object.keys(resolvedHeaders).length > 0 ? resolvedHeaders : undefined,
+          };
+        } else {
+          // stdio MCP server — resolve $VAR in env
+          const resolvedEnv: Record<string, string> = {};
+          if (server.env) {
+            for (const [key, val] of Object.entries(server.env as Record<string, string>)) {
+              if (val.startsWith('$')) {
+                const envName = val.slice(1);
+                const envValue = process.env[envName];
+                if (envValue === undefined) {
+                  console.warn(`[config] MCP server "${name}" for team "${id}": env var ${envName} is not set (key: ${key})`);
+                }
+                resolvedEnv[key] = envValue ?? '';
+              } else {
+                resolvedEnv[key] = val;
+              }
+            }
+          }
+          mcpServers[name] = {
+            command: server.command,
+            args: server.args,
+            env: Object.keys(resolvedEnv).length > 0 ? resolvedEnv : undefined,
+          };
         }
-        mcpServers[name] = {
-          command: server.command,
-          args: server.args,
-          env: Object.keys(resolvedEnv).length > 0 ? resolvedEnv : undefined,
-        };
       }
     }
 

--- a/src/orchestrator/__tests__/mcp-config.test.ts
+++ b/src/orchestrator/__tests__/mcp-config.test.ts
@@ -1,0 +1,82 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import fs from 'node:fs';
+import path from 'node:path';
+import os from 'node:os';
+
+vi.mock('../../utils/fs.js', () => ({
+  atomicWriteSync: vi.fn(),
+}));
+
+import { writeMcpConfig } from '../mcp-config.js';
+import { atomicWriteSync } from '../../utils/fs.js';
+
+describe('writeMcpConfig', () => {
+  let tmpDir: string;
+
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'mcp-test-'));
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it('writes stdio MCP server config', () => {
+    writeMcpConfig('test-team', {
+      notion: {
+        command: 'npx',
+        args: ['-y', '@notionhq/notion-mcp-server'],
+        env: { TOKEN: 'abc' },
+      },
+    }, tmpDir);
+
+    const [filePath, content] = (atomicWriteSync as ReturnType<typeof vi.fn>).mock.calls[0];
+    expect(filePath).toContain('test-team.json');
+    const parsed = JSON.parse(content);
+    expect(parsed.mcpServers.notion).toEqual({
+      command: 'npx',
+      args: ['-y', '@notionhq/notion-mcp-server'],
+      env: { TOKEN: 'abc' },
+    });
+  });
+
+  it('writes HTTP MCP server config', () => {
+    writeMcpConfig('test-team', {
+      figma: {
+        type: 'http',
+        url: 'https://mcp.figma.com/mcp',
+        headers: { 'X-Figma-Token': 'figd_test123' },
+      },
+    }, tmpDir);
+
+    const [filePath, content] = (atomicWriteSync as ReturnType<typeof vi.fn>).mock.calls[0];
+    expect(filePath).toContain('test-team.json');
+    const parsed = JSON.parse(content);
+    expect(parsed.mcpServers.figma).toEqual({
+      type: 'http',
+      url: 'https://mcp.figma.com/mcp',
+      headers: { 'X-Figma-Token': 'figd_test123' },
+    });
+  });
+
+  it('writes mixed stdio and HTTP servers together', () => {
+    writeMcpConfig('test-team', {
+      notion: {
+        command: 'npx',
+        args: ['-y', '@notionhq/notion-mcp-server'],
+      },
+      figma: {
+        type: 'http',
+        url: 'https://mcp.figma.com/mcp',
+        headers: { 'X-Figma-Token': 'token123' },
+      },
+    }, tmpDir);
+
+    const [, content] = (atomicWriteSync as ReturnType<typeof vi.fn>).mock.calls[0];
+    const parsed = JSON.parse(content);
+    expect(parsed.mcpServers.notion.command).toBe('npx');
+    expect(parsed.mcpServers.figma.type).toBe('http');
+    expect(parsed.mcpServers.figma.url).toBe('https://mcp.figma.com/mcp');
+  });
+});

--- a/src/types.ts
+++ b/src/types.ts
@@ -2,11 +2,20 @@ export type TeamId = string;
 
 export type Engine = 'claude' | 'codex' | 'gemini';
 
-export interface McpServerConfig {
+export interface McpServerStdioConfig {
+  type?: 'stdio';
   command: string;
   args?: string[];
   env?: Record<string, string>;
 }
+
+export interface McpServerHttpConfig {
+  type: 'http';
+  url: string;
+  headers?: Record<string, string>;
+}
+
+export type McpServerConfig = McpServerStdioConfig | McpServerHttpConfig;
 
 export interface GitIdentity {
   name: string;


### PR DESCRIPTION
## Summary
- `McpServerConfig` 타입을 stdio/http 유니온으로 확장하여 HTTP 기반 MCP 서버(Figma 등)를 봇 런타임에서 로드 가능하도록 수정
- `config.ts`에서 `type` 필드 기준 분기 처리 추가 (HTTP headers의 `$VAR` 환경변수 확장 포함)
- MCP config 직렬화 테스트 3건 추가 (stdio, HTTP, mixed)

## Changes
- `src/types.ts`: `McpServerConfig` → `McpServerStdioConfig | McpServerHttpConfig` 유니온 타입
- `src/config.ts`: HTTP 서버 로드 로직 추가 (headers 환경변수 해석)
- `src/orchestrator/__tests__/mcp-config.test.ts`: 신규 테스트 3건

## Test plan
- [x] TypeScript 컴파일 에러 없음 (`tsc --noEmit`)
- [x] 기존 52건 + 신규 3건 = 55건 전체 통과
- [ ] 봇 재시작 후 브러쉬코코 Figma MCP 도구 로드 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)