### PR TITLE
chore: bump version to 0.8.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "claude-mococo",
-  "version": "0.7.0",
+  "version": "0.8.0",
   "description": "AI Team Company on Discord — multi-engine AI agents as distinct team identities",
   "type": "module",
   "license": "MIT",


### PR DESCRIPTION
## Summary
- `package.json` 버전 0.7.0 → 0.8.0으로 업데이트
- PR #63 HTTP MCP 서버 타입 지원 추가 반영

## Test plan
- [ ] `npm run build` 정상 빌드 확인
- [ ] `npm run test` 전체 테스트 통과 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)