### PR TITLE
docs. README 한글/영어 버전 현행화 (v0.7.0 기준)

### DIFF
--- a/README.ko.md
+++ b/README.ko.md
@@ -1,12 +1,14 @@
 # claude-mococo
 
-**Discord 위의 AI 어시스턴트.** 각 어시스턴트는 AI 엔진(Claude, Codex, Gemini)으로 구동되는 실제 Discord 봇입니다. 고유한 GitHub 계정, 성격, 권한을 가집니다. 하나부터 시작해서 필요할 때 더 추가하세요.
+**Discord 위의 AI 팀 컴퍼니.** 여러 AI 에이전트가 각자의 Discord 봇 신원으로 함께 작동합니다 — 고유한 성격, GitHub 신원, 엔진(Claude/Codex/Gemini), 권한을 가집니다. 오케스트레이션은 Discord 메시지를 통해 이루어집니다: 사람이 말하면 에이전트들이 조율하고, 코드를 커밋하고 PR을 올립니다.
 
 ```
 나: "my-app에 로그인 페이지 만들어줘"
 
-어시스턴트 (봇): "알겠습니다. 인증 라우트와 로그인 폼을 만들게요."
-              → 코드 커밋 → 브랜치 푸시 → PR 생성
+Leader (봇): "알겠습니다. @Backend 인증 라우트와 로그인 폼 구현 부탁해요."
+Backend (봇): "바로 할게요."
+             → 코드 커밋 → 브랜치 푸시
+Review (봇): → 코드 리뷰 → PR 생성
 ```
 
 ---
@@ -17,6 +19,14 @@
 
 ```bash
 npm install -g claude-mococo
+```
+
+설치 없이 바로 실행도 가능합니다:
+
+```bash
+npx claude-mococo init
+npx claude-mococo add
+npx claude-mococo start
 ```
 
 AI 엔진도 최소 하나 필요합니다:
@@ -39,6 +49,8 @@ npm install -g @google/gemini-cli # Gemini CLI (선택)
    - Permissions: `Send Messages`, `Read Message History`, `Embed Links`, `Attach Files`
    - URL 복사 → 브라우저에서 열기 → 서버에 추가
 
+실행할 에이전트 수만큼 반복합니다.
+
 ### 3. 워크스페이스 생성 및 어시스턴트 추가
 
 ```bash
@@ -47,7 +59,7 @@ mococo init                   # 워크스페이스 생성 (Discord 채널 ID 입
 mococo add                    # 대화형 마법사 — 이름, 엔진, 토큰 등 입력
 ```
 
-커밋에는 어시스턴트 이름이 작성자로 표시됩니다 (`teams.json`의 `git.name`으로 설정). 어시스턴트가 푸시나 PR을 생성해야 하면 `mococo add` 시 GitHub PAT를 입력하세요.
+커밋에는 어시스턴트 이름이 작성자로 표시됩니다 (`teams.json`의 `git.name`으로 설정). 푸시나 PR 생성이 필요하면 `mococo add` 시 GitHub PAT를 입력하세요.
 
 ### 4. 저장소 연결 및 시작
 
@@ -67,45 +79,42 @@ Discord 채널에서 봇에게 말을 걸면 됩니다.
 | `mococo init` | 현재 디렉토리에 워크스페이스 생성 |
 | `mococo add` | 어시스턴트 추가 (대화형 마법사) |
 | `mococo start` | 모든 어시스턴트 시작 |
+| `mococo dev` | 핫 리로드 개발 모드로 시작 |
 | `mococo list` | 설정된 어시스턴트 목록 |
+| `mococo edit <id>` | 어시스턴트 설정 편집 |
 | `mococo remove <id>` | 어시스턴트 제거 |
+| `mococo restart` | 리빌드 및 재시작 트리거 |
 
 ---
 
-## 어시스턴트 추가하기
+## 팀 아키텍처
 
-```bash
-mococo add        # 새 어시스턴트마다 반복
-```
+일반적인 풀 팀 구성:
 
-각 어시스턴트는:
-- 고유한 Discord 봇 (채팅에서 별도 신원)
-- 고유한 git 작성자 이름 (커밋 메시지에 표시)
-- `teams.json`의 별도 항목 (엔진, 성격, 권한)
+| 어시스턴트 | 엔진 | 모델 | 역할 | 권한 |
+|-----------|------|------|------|------|
+| **Leader** | Claude | opus | 팀 조율, 작업 위임, 모든 메시지에 응답 | 읽기 전용 |
+| **Planner** | Codex | o3 | 아키텍처 계획 및 스펙 작성 | 읽기 전용 |
+| **Backend** | Claude | sonnet | 서버 코드, API, 모델 구현 | 파일 편집 + 로컬 커밋 |
+| **Frontend** | Claude | sonnet | UI, 컴포넌트, CSS 구현 | 파일 편집 + 로컬 커밋 |
+| **Reviewer** | Claude | opus | 코드 리뷰, 브랜치 푸시, PR 생성 | 푸시 + PR 생성 |
+| **Designer** | Gemini | gemini-2.5-pro | UI/UX 가이드 (텍스트 어드바이저) | 읽기 전용 |
 
-이렇게 팀을 구성할 수 있습니다:
-
-| 어시스턴트 | 엔진 | 역할 |
-|-----------|------|------|
-| Leader | Claude | 다른 어시스턴트에게 작업 위임 |
-| Planner | Codex | 계획 및 스펙 작성 |
-| Coder | Claude | 코드 작성 |
-| Reviewer | Claude | 리뷰 및 PR 생성 |
-| Designer | Gemini | UI/UX 가이드 |
-
-혼자 하나만 써도 됩니다. 선택은 자유입니다.
+하나부터 시작해서 필요할 때 더 추가할 수 있습니다.
 
 ---
 
 ## 작동 방식
 
-**메시지 라우팅:**
-- 특정 봇을 `@멘션` → 해당 어시스턴트가 응답
+### 메시지 라우팅
+
 - 멘션 없음 → `"isLeader": true`인 어시스턴트가 응답
+- 특정 봇을 `@멘션` → 해당 어시스턴트가 응답
+- 어시스턴트가 다른 어시스턴트를 멘션 → 자동으로 호출
 
-**어시스턴트가 다른 어시스턴트를 멘션하면** (예: `@Reviewer 확인 부탁`) → 자동으로 호출됩니다.
+### 권한
 
-**권한**은 `teams.json`에서 어시스턴트별로 제어합니다:
+`teams.json`에서 어시스턴트별로 설정:
 
 ```jsonc
 "permissions": {
@@ -114,7 +123,55 @@ mococo add        # 새 어시스턴트마다 반복
 }
 ```
 
-**엔진:** `"claude"`는 풀 에이전트(파일, git, 명령어). `"codex"`와 `"gemini"`는 텍스트 전용 어드바이저.
+일반적인 권한 단계:
+- **Leader / Planner / Designer:** 읽기 전용. 파일 편집·git 불가.
+- **Backend / Frontend:** 파일 편집, 로컬 커밋 가능. 푸시·PR 불가.
+- **Reviewer:** 브랜치 푸시·PR 생성 가능. 머지 불가.
+- **전체 에이전트:** `gh pr merge`, `git push --force main/master` 전역 차단.
+
+### 엔진
+
+- `"claude"` — 풀 에이전트 (파일, git, 쉘 명령어 — Claude CLI 사용)
+- `"codex"` — 풀 에이전트 (Codex CLI — OpenAI)
+- `"gemini"` — 텍스트 전용 어드바이저 (Gemini CLI)
+
+### 메모리 & 인박스 시스템
+
+각 에이전트는 **인박스** (`.mococo/inbox/{id}.md`)를 가지며 메시지가 도착할 때마다 기록됩니다. 호출 시 에이전트는 다음을 전달받습니다:
+- 최근 대화 기록 (설정 가능한 윈도우)
+- 인박스 요약
+- 장기 메모리 (`.mococo/memory/`)
+- `CLAUDE.md`의 공유 규칙
+
+**Haiku 모델** (경량 Claude)이 트리아지 작업을 처리합니다: 인박스 요약, 개선점 스캔, 하트비트 판단.
+
+### 하트비트 & 스케줄 태스크
+
+리더가 **3분마다** 하트비트를 실행합니다. 워크스페이스 루트에 `heartbeat.md`가 있으면 스케줄 태스크가 파싱됩니다:
+
+| 섹션 | 주기 | 설명 |
+|------|------|------|
+| `## Daily` | 하루 1회 (첫 번째 하트비트) | 매일 반복 태스크 |
+| `## Weekly` | 주 1회 (월요일 첫 번째 하트비트) | 매주 반복 태스크 |
+| `## Hourly` | 시간당 1회 | 시간별 모니터링 태스크 |
+| `## Periodic` | 하트비트마다 (~3분) | 경량 모니터링 |
+| `## On-demand` | 수동 트리거만 | 일회성 태스크 |
+
+태스크 형식:
+
+```markdown
+- [ ] 태스크 설명 @담당자
+```
+
+- `- [ ]` = 활성 (처리됨)
+- `- [x]` = 비활성 (스킵)
+- `@담당자` = 선택 사항, 특정 어시스턴트에게 라우팅
+
+상태는 `.mococo/heartbeat-state.json`에 추적되어 Daily/Weekly 태스크 중복 실행을 방지합니다.
+
+### 디스패치 레저
+
+리더가 다른 에이전트에게 작업을 위임하면 디스패치 레저에 기록됩니다. 리더는 위임된 작업 완료 여부를 추적하고 필요 시 팔로업합니다.
 
 ---
 
@@ -129,14 +186,43 @@ mococo add        # 새 어시스턴트마다 반복
 | `maxBudget` | 호출당 최대 비용 (Claude만 해당) |
 | `prompt` | 성격/지시사항 파일 경로 |
 | `isLeader` | `true`면 모든 메시지에 응답 (@멘션 불필요) |
+| `discordTokenEnv` | 봇 토큰이 저장된 환경변수 이름 |
 | `git.name` / `git.email` | 커밋 작성자 정보 |
 | `permissions.allow` / `permissions.deny` | 허용/차단 쉘 명령어 |
+| `mcpServers` | MCP 서버 설정 (예: Google Calendar) |
+
+### 전역 설정
+
+| 필드 | 설명 |
+|------|------|
+| `globalDeny` | 전체 에이전트에서 차단할 명령어 |
+| `conversationWindow` | 프롬프트에 포함할 최근 메시지 수 (기본값: 30) |
+| `humanTitle` | 에이전트에게 표시될 사람 호칭 (기본값: `"Boss"`) |
+
+### 환경변수
+
+```bash
+WORK_CHANNEL_ID=              # 작업할 Discord 채널 (비우면 전체 채널)
+HOOK_PORT=9876                # HTTP 웹훅 수신 포트
+
+# 봇 토큰 (봇 1개당 1개)
+LEADER_DISCORD_TOKEN=...
+BACKEND_DISCORD_TOKEN=...
+FRONTEND_DISCORD_TOKEN=...
+PLANNING_DISCORD_TOKEN=...
+REVIEW_DISCORD_TOKEN=...
+DESIGN_DISCORD_TOKEN=...
+
+# 선택적 연동
+GOOGLE_OAUTH_CREDENTIALS=...  # Google Calendar MCP (Leader용)
+GITHUB_PAT=...                # 푸시/PR에 필요
+```
 
 ### Discord 명령어
 
 | 명령어 | 설명 |
 |--------|------|
-| `!status` | 모든 어시스턴트 상태 (작업 중/유휴, 온라인/오프라인) |
+| `!status` | 모든 어시스턴트 상태 (작업 중/유휴, 엔진, 비용) |
 | `!teams` | 어시스턴트 목록과 엔진 |
 | `!repos` | 연결된 저장소 목록 |
 
@@ -144,15 +230,18 @@ mococo add        # 새 어시스턴트마다 반복
 
 ## 수동 설정 (CLI 없이)
 
-저장소를 직접 클론해서 설정할 수도 있습니다:
-
 ```bash
-git clone https://github.com/anthropics/claude-mococo.git
+git clone https://github.com/wodn5515/claude-mococo.git
 cd claude-mococo
 npm install
+npm run build
 ```
 
-`teams.json`을 직접 편집하고, `prompts/`에 프롬프트 파일을 만들고, `.env`에 토큰을 설정한 후 `npm start`로 실행합니다.
+`teams.json`을 직접 편집하고, `prompts/`에 프롬프트 파일을 만들고, `.env`에 토큰을 설정한 후 실행:
+
+```bash
+npm start
+```
 
 ---
 
@@ -165,6 +254,10 @@ npm install
 | GitHub 푸시 불가 | `.env`의 GitHub PAT 확인 |
 | 커밋 작성자 틀림 | `git.email`을 `USERNAME@users.noreply.github.com`으로 설정 |
 | "command not found: codex" | 설치하거나 engine을 `"claude"`로 변경 |
+| 하트비트 미동작 | 워크스페이스 루트에 `heartbeat.md` 존재 여부 확인 |
+| 에이전트 무한 루프 | `teams.json`에 `maxBudget` 설정 확인 |
+
+---
 
 ## 라이선스
 

--- a/README.md
+++ b/README.md
@@ -1,12 +1,14 @@
 # claude-mococo
 
-**AI assistants on Discord.** Each assistant is a real Discord bot backed by an AI engine (Claude, Codex, Gemini). It has its own GitHub account, personality, and permissions. Start with one, add more when you need them.
+**AI team company on Discord.** Multiple AI agents work together as distinct Discord bots — each with its own personality, GitHub identity, engine (Claude/Codex/Gemini), and permissions. Orchestration happens through Discord messages: human talks, agents coordinate, code gets committed and PRs get opened.
 
 ```
 You: "Add a login page to my-app"
 
-Assistant (bot): "On it. I'll create the auth routes and login form."
-               → commits code → pushes branch → opens PR
+Leader (bot): "On it. @Backend please implement auth routes and login form."
+Backend (bot): "Got it."
+             → commits code → pushes branch
+Review (bot): → reviews code → opens PR
 ```
 
 ---
@@ -47,17 +49,19 @@ npm install -g @google/gemini-cli # Gemini CLI (optional)
    - Permissions: `Send Messages`, `Read Message History`, `Embed Links`, `Attach Files`
    - Copy the URL → open in browser → add to your server
 
-### 3. Initialize and add your assistant
+Repeat for each agent you plan to run.
+
+### 3. Initialize and add assistants
 
 ```bash
 mkdir my-team && cd my-team
 mococo init                   # creates workspace (asks for Discord channel ID)
-mococo add                    # interactive wizard — asks for name, engine, tokens, etc.
+mococo add                    # interactive wizard — name, engine, tokens, etc.
 ```
 
-Commits will show the assistant's name as the author (configured via `git.name` in `teams.json`). If you need assistants to push or create PRs, provide your GitHub PAT during `mococo add`.
+Commits will show the assistant's name as the author (`git.name` in `teams.json`). For push and PR creation, provide a GitHub PAT during `mococo add`.
 
-### 4. Link your repos and start
+### 4. Link repos and start
 
 ```bash
 ln -s /path/to/my-app repos/my-app
@@ -75,45 +79,42 @@ Talk to your bot in the Discord channel. Done.
 | `mococo init` | Create a new workspace in the current directory |
 | `mococo add` | Add an assistant (interactive wizard) |
 | `mococo start` | Start all assistants |
+| `mococo dev` | Start in dev mode with hot reload |
 | `mococo list` | List configured assistants |
+| `mococo edit <id>` | Edit assistant settings |
 | `mococo remove <id>` | Remove an assistant |
+| `mococo restart` | Trigger rebuild and restart |
 
 ---
 
-## Adding More Assistants
+## Team Architecture
 
-```bash
-mococo add        # repeat for each new assistant
-```
+A typical full team looks like this:
 
-Each one gets:
-- Its own Discord bot (separate identity in chat)
-- Its own git author name (visible in commit messages)
-- Its own entry in `teams.json` (engine, personality, permissions)
+| Assistant | Engine | Model | Role | Permissions |
+|-----------|--------|-------|------|-------------|
+| **Leader** | Claude | opus | Coordinates team, delegates work, responds to all messages | Read-only |
+| **Planner** | Codex | o3 | Creates architecture plans and specs | Read-only |
+| **Backend** | Claude | sonnet | Implements server code, APIs, models | Edit files + local commits |
+| **Frontend** | Claude | sonnet | Implements UI, components, CSS | Edit files + local commits |
+| **Reviewer** | Claude | opus | Code review, branch push, PR creation | Push + PR create |
+| **Designer** | Gemini | gemini-2.5-pro | UI/UX guidance (text advisor only) | Read-only |
 
-You can build a full team this way:
-
-| Assistant | Engine | Role |
-|-----------|--------|------|
-| Leader | Claude | Delegates work to other assistants |
-| Planner | Codex | Creates plans and specs |
-| Coder | Claude | Writes code |
-| Reviewer | Claude | Reviews and opens PRs |
-| Designer | Gemini | UI/UX guidance |
-
-Or just run a single assistant. It's up to you.
+You can start with just one assistant and add more over time.
 
 ---
 
 ## How It Works
 
-**Message routing:**
-- If you `@mention` a specific bot → that assistant responds
-- If no mention → the first assistant marked `"isLeader": true` responds
+### Message Routing
 
-**When an assistant mentions another** (e.g. `@Reviewer please check this`) → that assistant is automatically invoked.
+- No mention → the assistant marked `"isLeader": true` responds
+- `@mention` a specific bot → that assistant responds
+- An assistant mentions another → that assistant is automatically invoked
 
-**Permissions** are controlled per-assistant in `teams.json`:
+### Permissions
+
+Controlled per-assistant in `teams.json`:
 
 ```jsonc
 "permissions": {
@@ -122,29 +123,55 @@ Or just run a single assistant. It's up to you.
 }
 ```
 
-**Engines:** `"claude"` runs as a full agent (files, git, commands). `"codex"` and `"gemini"` run as text-only advisors.
+Typical permission tiers:
+- **Leader / Planner / Designer:** Read-only. No file edits, no git.
+- **Backend / Frontend:** Edit files, commit locally. No push or PRs.
+- **Reviewer:** Push branches and open PRs. No merges.
+- **All agents:** `gh pr merge` and `git push --force main/master` globally denied.
 
-**Heartbeat & Scheduled Tasks:**
+### Engines
 
-The leader assistant runs a heartbeat every 3 minutes. If a `heartbeat.md` file exists in the workspace root, it is parsed for scheduled tasks:
+- `"claude"` — full agent (files, git, shell commands via Claude CLI)
+- `"codex"` — full agent via Codex CLI (OpenAI)
+- `"gemini"` — text-only advisor (Gemini CLI)
+
+### Memory & Inbox System
+
+Each agent has an **inbox** (`.mococo/inbox/{id}.md`) where messages are appended as they arrive. When invoked, an agent receives:
+- Recent conversation history (configurable window)
+- Its inbox summary
+- Consolidated long-term memory (`.mococo/memory/`)
+- Shared rules from `CLAUDE.md`
+
+A **Haiku model** (lightweight Claude) handles triage tasks: inbox summarization, improvement scanning, heartbeat decisions.
+
+### Heartbeat & Scheduled Tasks
+
+The leader runs a heartbeat every **3 minutes**. If `heartbeat.md` exists in the workspace root, it is parsed for scheduled tasks:
 
 | Section | Frequency | Description |
 |---------|-----------|-------------|
 | `## Daily` | Once per day (first heartbeat) | Daily recurring tasks |
 | `## Weekly` | Once per week (Monday, first heartbeat) | Weekly recurring tasks |
-| `## Periodic` | Every heartbeat (3 min) | Lightweight monitoring tasks |
-| `## On-demand` | Manual trigger only | One-off or special tasks |
+| `## Hourly` | Once per hour | Hourly monitoring tasks |
+| `## Periodic` | Every heartbeat (~3 min) | Lightweight monitoring |
+| `## On-demand` | Manual trigger only | One-off tasks |
 
 Task format:
+
 ```markdown
 - [ ] Task description @assignee
 ```
 
-- `- [ ]` = active (processed by heartbeat)
+- `- [ ]` = active (processed)
 - `- [x]` = inactive (skipped)
 - `@assignee` = optional, routes to a specific assistant
 
-State is tracked in `.mococo/heartbeat-state.json` to avoid re-running daily/weekly tasks.
+State is tracked in `.mococo/heartbeat-state.json` to prevent re-running daily/weekly tasks.
+
+### Dispatch Ledger
+
+When the leader delegates work to another agent, it's recorded in a dispatch ledger. The leader tracks whether delegated work was completed and follows up if needed.
 
 ---
 
@@ -159,22 +186,49 @@ State is tracked in `.mococo/heartbeat-state.json` to avoid re-running daily/wee
 | `maxBudget` | Max dollar spend per invocation (Claude only) |
 | `prompt` | Path to the personality/instructions file |
 | `isLeader` | If `true`, responds to all messages (not just @mentions) |
+| `discordTokenEnv` | Environment variable name containing the bot token |
 | `git.name` / `git.email` | Git author for commits |
 | `permissions.allow` / `permissions.deny` | Allowed/denied shell commands |
+| `mcpServers` | MCP server configurations (e.g. Google Calendar) |
+
+### Global settings
+
+| Field | Description |
+|-------|-------------|
+| `globalDeny` | Commands forbidden across all agents |
+| `conversationWindow` | Number of recent messages in prompts (default: 30) |
+| `humanTitle` | Title for the human user shown to agents (default: `"Boss"`) |
+
+### Environment variables
+
+```bash
+WORK_CHANNEL_ID=              # Discord channel to work in (empty = all channels)
+HOOK_PORT=9876                # HTTP webhook receiver port
+
+# One token per bot
+LEADER_DISCORD_TOKEN=...
+BACKEND_DISCORD_TOKEN=...
+FRONTEND_DISCORD_TOKEN=...
+PLANNING_DISCORD_TOKEN=...
+REVIEW_DISCORD_TOKEN=...
+DESIGN_DISCORD_TOKEN=...
+
+# Optional integrations
+GOOGLE_OAUTH_CREDENTIALS=...  # Google Calendar MCP (for Leader)
+GITHUB_PAT=...                # Required for push/PR
+```
 
 ### Discord commands
 
 | Command | Description |
 |---------|-------------|
-| `!status` | Show all assistants (busy/idle, online/offline) |
+| `!status` | Show all assistants (busy/idle, engine, cost) |
 | `!teams` | List assistants and their engines |
 | `!repos` | List linked repositories |
 
 ---
 
 ## Manual Setup (without CLI)
-
-You can also set up manually by cloning the repo:
 
 ```bash
 git clone https://github.com/wodn5515/claude-mococo.git
@@ -183,7 +237,11 @@ npm install
 npm run build
 ```
 
-Edit `teams.json` directly, create prompt files in `prompts/`, set tokens in `.env`, then `npm start`.
+Edit `teams.json` directly, create prompt files in `prompts/`, set tokens in `.env`, then run:
+
+```bash
+npm start
+```
 
 ---
 
@@ -196,6 +254,10 @@ Edit `teams.json` directly, create prompt files in `prompts/`, set tokens in `.e
 | Can't push to GitHub | Check the GitHub PAT in `.env` is valid |
 | Wrong commit author | Set `git.email` to `USERNAME@users.noreply.github.com` |
 | "command not found: codex" | Install it or change engine to `"claude"` |
+| Heartbeat not triggering | Check `heartbeat.md` exists in workspace root |
+| Agent loops indefinitely | Check `maxBudget` is set in `teams.json` |
+
+---
 
 ## License
 


### PR DESCRIPTION
## Summary
- 팀 구성 6개 에이전트 실제 구현 기준으로 반영 (Leader/Planner/Backend/Frontend/Reviewer/Designer + 엔진/모델/권한)
- Hourly 섹션, 디스패치 레저, 메모리 & 인박스 시스템 신규 추가
- CLI 명령어 `dev`, `edit`, `restart` 누락분 추가
- 수동 설정 GitHub URL `wodn5515/claude-mococo`로 수정
- 한글/영어 버전 동시 업데이트 (`README.md` + `README.ko.md`)

## Test plan
- [ ] README.md 영어 버전 내용 검토
- [ ] README.ko.md 한글 버전 내용 검토
- [ ] 팀 구조 테이블 실제 teams.json과 일치 여부 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)