### PR TITLE
fix. improvement-scanner 오진율 개선 (#433)

### DIFF
--- a/src/bot/__tests__/improvement-scanner.test.ts
+++ b/src/bot/__tests__/improvement-scanner.test.ts
@@ -1,0 +1,263 @@
+import { describe, it, expect } from 'vitest';
+
+import { isTestFile, buildScanPrompt, parseHaikuOutput, issueKey } from '../improvement-scanner.js';
+
+// ---------------------------------------------------------------------------
+// isTestFile
+// ---------------------------------------------------------------------------
+
+describe('isTestFile', () => {
+  it('detects Python test files', () => {
+    expect(isTestFile('tests/test_auth.py')).toBe(true);
+    expect(isTestFile('backend/tests/test_share_link_use_case.py')).toBe(true);
+    expect(isTestFile('test_something.py')).toBe(true);
+    expect(isTestFile('backend/app/auth_test.py')).toBe(true);
+  });
+
+  it('detects conftest.py', () => {
+    expect(isTestFile('tests/conftest.py')).toBe(true);
+    expect(isTestFile('conftest.py')).toBe(true);
+  });
+
+  it('detects TypeScript/JS test files', () => {
+    expect(isTestFile('src/bot/__tests__/foo.test.ts')).toBe(true);
+    expect(isTestFile('utils/helper.spec.js')).toBe(true);
+    expect(isTestFile('src/foo.test.js')).toBe(true);
+  });
+
+  it('detects test directories', () => {
+    expect(isTestFile('tests/helpers/factory.py')).toBe(true);
+    expect(isTestFile('src/__tests__/setup.ts')).toBe(true);
+    expect(isTestFile('test/fixtures/data.json')).toBe(true);
+  });
+
+  it('does NOT flag production files', () => {
+    expect(isTestFile('src/bot/client.ts')).toBe(false);
+    expect(isTestFile('backend/app/services/auth.py')).toBe(false);
+    expect(isTestFile('utils/haiku.ts')).toBe(false);
+    expect(isTestFile('backend/app/models/property.py')).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// parseHaikuOutput — evidence-based filtering
+// ---------------------------------------------------------------------------
+
+describe('parseHaikuOutput', () => {
+  it('accepts issues with line and evidence', () => {
+    const output = JSON.stringify([
+      {
+        file: 'src/app.ts',
+        repo: 'test-repo',
+        type: 'security',
+        severity: 'high',
+        line: 42,
+        evidence: 'const secret = "hardcoded"',
+        description: '하드코딩된 시크릿',
+        suggestion: '환경변수로 이동',
+      },
+    ]);
+    const result = parseHaikuOutput(output);
+    expect(result).toHaveLength(1);
+    expect(result[0].line).toBe(42);
+    expect(result[0].evidence).toBe('const secret = "hardcoded"');
+  });
+
+  it('discards issues without line number', () => {
+    const output = JSON.stringify([
+      {
+        file: 'src/app.ts',
+        repo: 'test-repo',
+        type: 'security',
+        severity: 'high',
+        description: '추론 기반 이슈',
+        suggestion: '확인 필요',
+      },
+    ]);
+    const result = parseHaikuOutput(output);
+    expect(result).toHaveLength(0);
+  });
+
+  it('discards issues with line=0', () => {
+    const output = JSON.stringify([
+      {
+        file: 'src/app.ts',
+        repo: 'test-repo',
+        type: 'security',
+        severity: 'medium',
+        line: 0,
+        evidence: 'some code',
+        description: '라인 0 이슈',
+        suggestion: '수정 필요',
+      },
+    ]);
+    const result = parseHaikuOutput(output);
+    expect(result).toHaveLength(0);
+  });
+
+  it('discards issues without evidence', () => {
+    const output = JSON.stringify([
+      {
+        file: 'src/app.ts',
+        repo: 'test-repo',
+        type: 'performance',
+        severity: 'medium',
+        line: 15,
+        evidence: '',
+        description: '증거 없는 이슈',
+        suggestion: '확인 필요',
+      },
+    ]);
+    const result = parseHaikuOutput(output);
+    expect(result).toHaveLength(0);
+  });
+
+  it('handles markdown-fenced JSON', () => {
+    const output = '```json\n' + JSON.stringify([
+      {
+        file: 'src/app.ts',
+        repo: 'test-repo',
+        type: 'refactoring',
+        severity: 'low',
+        line: 10,
+        evidence: 'duplicateCode()',
+        description: '중복 코드',
+        suggestion: '함수 추출',
+      },
+    ]) + '\n```';
+    const result = parseHaikuOutput(output);
+    expect(result).toHaveLength(1);
+  });
+
+  it('returns empty array for invalid JSON', () => {
+    expect(parseHaikuOutput('not json at all')).toEqual([]);
+    expect(parseHaikuOutput('')).toEqual([]);
+  });
+
+  it('filters mixed valid and invalid items', () => {
+    const output = JSON.stringify([
+      {
+        file: 'src/good.ts',
+        repo: 'test-repo',
+        type: 'security',
+        severity: 'high',
+        line: 5,
+        evidence: 'eval(userInput)',
+        description: '유효한 이슈',
+        suggestion: '수정 필요',
+      },
+      {
+        file: 'src/bad.ts',
+        repo: 'test-repo',
+        type: 'security',
+        severity: 'high',
+        description: '라인 없는 이슈',
+        suggestion: '추론',
+      },
+      {
+        file: 'src/also-bad.ts',
+        repo: 'test-repo',
+        type: 'unknown-type',
+        severity: 'high',
+        line: 1,
+        evidence: 'code',
+        description: '잘못된 타입',
+        suggestion: '수정',
+      },
+    ]);
+    const result = parseHaikuOutput(output);
+    expect(result).toHaveLength(1);
+    expect(result[0].file).toBe('src/good.ts');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// buildScanPrompt — test file tagging & evidence rules
+// ---------------------------------------------------------------------------
+
+describe('buildScanPrompt', () => {
+  it('tags test files with [TEST FILE]', () => {
+    const prompt = buildScanPrompt('my-repo', [
+      { filePath: 'src/app.ts', content: 'const x = 1;' },
+      { filePath: 'tests/conftest.py', content: 'import pytest' },
+      { filePath: 'tests/test_auth.py', content: 'def test_login(): pass' },
+    ]);
+    expect(prompt).toContain('src/app.ts');
+    expect(prompt).not.toContain('src/app.ts [TEST FILE]');
+    expect(prompt).toContain('tests/conftest.py [TEST FILE]');
+    expect(prompt).toContain('tests/test_auth.py [TEST FILE]');
+  });
+
+  it('includes evidence-based analysis rules', () => {
+    const prompt = buildScanPrompt('my-repo', [
+      { filePath: 'src/main.ts', content: 'console.log("hello");' },
+    ]);
+    expect(prompt).toContain('Evidence-Based Analysis Rules');
+    expect(prompt).toContain('"line"');
+    expect(prompt).toContain('"evidence"');
+    expect(prompt).toContain('false positives');
+  });
+
+  it('includes false positive prevention for test files', () => {
+    const prompt = buildScanPrompt('my-repo', [
+      { filePath: 'src/main.ts', content: 'code' },
+    ]);
+    expect(prompt).toContain('Hardcoded values in test files');
+    expect(prompt).toContain('test fixtures, not production secrets');
+  });
+
+  it('includes N+1 query false positive prevention', () => {
+    const prompt = buildScanPrompt('my-repo', [
+      { filePath: 'src/main.ts', content: 'code' },
+    ]);
+    expect(prompt).toContain('scalars().all()');
+    expect(prompt).toContain('N+1');
+  });
+
+  it('includes async false positive prevention', () => {
+    const prompt = buildScanPrompt('my-repo', [
+      { filePath: 'src/main.ts', content: 'code' },
+    ]);
+    expect(prompt).toContain('AsyncClient');
+  });
+
+  it('includes confidence threshold', () => {
+    const prompt = buildScanPrompt('my-repo', [
+      { filePath: 'src/main.ts', content: 'code' },
+    ]);
+    expect(prompt).toContain('80%');
+  });
+
+  it('includes existing issues to prevent re-reporting', () => {
+    const existing = [{
+      file: 'src/old.ts',
+      repo: 'my-repo',
+      type: 'security' as const,
+      severity: 'high' as const,
+      description: '기존 이슈',
+      suggestion: '수정 필요',
+    }];
+    const prompt = buildScanPrompt('my-repo', [
+      { filePath: 'src/main.ts', content: 'code' },
+    ], existing);
+    expect(prompt).toContain('Previously Reported Issues');
+    expect(prompt).toContain('기존 이슈');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// issueKey
+// ---------------------------------------------------------------------------
+
+describe('issueKey', () => {
+  it('generates consistent keys', () => {
+    const issue = { file: 'src/app.ts', repo: 'my-repo', type: 'security', description: 'test' };
+    expect(issueKey(issue)).toBe('my-repo::src/app.ts::security::test');
+  });
+
+  it('normalizes JSON-escaped repo names', () => {
+    const k1 = issueKey({ file: 'a.ts', repo: 'my-repo', type: 'security', description: 'x' });
+    const k2 = issueKey({ file: 'a.ts', repo: 'my\\u002Drepo', type: 'security', description: 'x' });
+    expect(k1).toBe(k2);
+  });
+});

--- a/src/bot/improvement-scanner.ts
+++ b/src/bot/improvement-scanner.ts
@@ -212,6 +212,31 @@ interface IssueItem {
   severity: 'high' | 'medium' | 'low';
   description: string;
   suggestion: string;
+  line?: number;
+  evidence?: string;
+}
+
+/**
+ * Detect if a file path is a test/fixture file (not production code).
+ */
+function isTestFile(filePath: string): boolean {
+  const name = path.basename(filePath);
+  // Normalize to always have a leading slash for consistent directory matching
+  const dir = ('/' + filePath).toLowerCase();
+  return (
+    name.startsWith('test_') ||
+    name.startsWith('tests_') ||
+    name.endsWith('_test.py') ||
+    name.endsWith('.test.ts') ||
+    name.endsWith('.test.js') ||
+    name.endsWith('.spec.ts') ||
+    name.endsWith('.spec.js') ||
+    name === 'conftest.py' ||
+    dir.includes('/tests/') ||
+    dir.includes('/test/') ||
+    dir.includes('/__tests__/') ||
+    dir.includes('/fixtures/')
+  );
 }
 
 function buildScanPrompt(
@@ -226,7 +251,8 @@ function buildScanPrompt(
         .replace(/```/g, '` ` `')
         .replace(/<\/?(?:system|instructions?|prompt|user|assistant|human|tool|function|message|turn|context)[^>]*>/gi, '&lt;sanitized&gt;')
         .replace(/<\|[^|]*\|>/g, '&lt;|sanitized|&gt;');
-      return `### ${JSON.stringify(f.filePath).slice(1, -1)}\n\`\`\`\n${sanitized}\n\`\`\``;
+      const testTag = isTestFile(f.filePath) ? ' [TEST FILE]' : '';
+      return `### ${JSON.stringify(f.filePath).slice(1, -1)}${testTag}\n\`\`\`\n${sanitized}\n\`\`\``;
     })
     .join('\n\n');
 
@@ -270,6 +296,22 @@ For each file, check for:
 4. **performance** -- inefficient algorithms, unnecessary I/O, memory leaks
 5. **code-quality** -- poor naming, missing types, inconsistent patterns, dead code
 
+## Evidence-Based Analysis Rules (CRITICAL)
+You MUST follow these rules to prevent false positives:
+
+1. **Line number required**: Every issue MUST reference a specific line number where the problem exists in the provided code. If you cannot point to a specific line, do NOT report it.
+2. **Evidence quote required**: Include a short code snippet (the exact line or expression) that demonstrates the issue.
+3. **Test files**: Files marked with [TEST FILE] are test/fixture code. Do NOT report:
+   - Hardcoded values in test files (IPs, URLs, credentials) — these are test fixtures, not production secrets
+   - Missing error handling in test code — tests intentionally exercise edge cases
+   - Performance issues in test code — test efficiency is not a production concern
+4. **Verify before reporting**: Only report issues you can directly observe in the provided code. Do NOT:
+   - Infer issues based on what code "might" exist elsewhere
+   - Report issues about code not shown (e.g., "this module probably has X problem")
+   - Assume synchronous behavior when the code clearly uses async patterns (e.g., AsyncClient, await)
+   - Flag ORM patterns like .scalars().all() + entity conversion as N+1 queries — this is a single query with in-memory mapping
+5. **When uncertain, skip**: If you are less than 80% confident an issue is real, do NOT report it. False negatives are acceptable; false positives waste team resources.
+
 ## Output Rules
 - Output ONLY a valid JSON array (no markdown fencing, no explanation)
 - Each element must follow this exact schema:
@@ -279,10 +321,14 @@ For each file, check for:
   "repo": "${safeRepoName}",
   "type": "refactoring|security|error-risk|performance|code-quality",
   "severity": "high|medium|low",
+  "line": 42,
+  "evidence": "exact code snippet from the line",
   "description": "문제 설명 (Korean)",
   "suggestion": "권장 해결 방안 (Korean)"
 }
 \`\`\`
+- "line" field is REQUIRED — issues without a specific line number will be discarded
+- "evidence" field is REQUIRED — must be a direct quote from the code shown above
 - Only report **NEW** genuine issues worth fixing. Do NOT fabricate issues.
 - Do NOT re-report previously reported issues unless the underlying code has significantly changed.
 - If a file ends with a "truncated" comment, do NOT report it as incomplete or broken — the code continues beyond what is shown.
@@ -494,7 +540,7 @@ function parseHaikuOutput(output: string): IssueItem[] {
     return parsed.filter((item): item is IssueItem => {
       if (typeof item !== 'object' || item === null) return false;
       const obj = item as Record<string, unknown>;
-      return (
+      const hasRequiredFields = (
         typeof obj.file === 'string' &&
         typeof obj.repo === 'string' &&
         typeof obj.type === 'string' && validTypes.has(obj.type) &&
@@ -502,6 +548,19 @@ function parseHaikuOutput(output: string): IssueItem[] {
         typeof obj.description === 'string' &&
         typeof obj.suggestion === 'string'
       );
+      if (!hasRequiredFields) return false;
+
+      // Require line number evidence — issues without specific line references are likely false positives
+      if (typeof obj.line !== 'number' || obj.line < 1) {
+        console.warn(`[improvement-scanner] Discarding issue without line number: ${obj.file} — ${String(obj.description).slice(0, 80)}`);
+        return false;
+      }
+      if (typeof obj.evidence !== 'string' || obj.evidence.trim().length === 0) {
+        console.warn(`[improvement-scanner] Discarding issue without evidence: ${obj.file}:${obj.line} — ${String(obj.description).slice(0, 80)}`);
+        return false;
+      }
+
+      return true;
     });
   } catch {
     console.warn('[improvement-scanner] Failed to parse Haiku JSON output');
@@ -520,7 +579,7 @@ let previousIssueKeys = new Set<string>();
 const NOTIFICATION_COOLDOWN_MS = 2 * 60 * 60 * 1000;
 let lastNotificationTime = 0;
 
-function issueKey(issue: { file: string; repo: string; type: string; description: string }): string {
+function issueKey(issue: { file: string; repo: string; type: string; description: string; line?: number }): string {
   return `${normalizeRepoName(issue.repo)}::${issue.file}::${issue.type}::${issue.description}`;
 }
 
@@ -677,3 +736,6 @@ export function stopImprovementScanner(): void {
   }
   console.log('[improvement-scanner] Stopped');
 }
+
+// Exported for testing
+export { isTestFile, buildScanPrompt, parseHaikuOutput, issueKey };


### PR DESCRIPTION
## Summary
- **테스트 파일 자동 감지**: `isTestFile()` 함수로 test/fixture 파일을 `[TEST FILE]` 태깅 → Haiku가 테스트 코드의 하드코딩 값, 에러 핸들링 부재 등을 오진하지 않도록 방지
- **증거 기반 분석 강제**: `line`(라인 번호) + `evidence`(코드 인용) 필드를 필수화하여, 추론 기반 이슈 생성 차단
- **오진 방지 프롬프트 강화**: ORM `.scalars().all()` 패턴을 N+1로 오진하는 케이스, `AsyncClient`를 동기로 오판하는 케이스 등 구체적 가이드라인 추가
- **파싱 검증 강화**: `parseHaikuOutput`에서 `line`/`evidence` 없는 이슈를 자동 폐기 (이중 안전장치)

### 오진 사례 대응 매핑
| 기존 오진 | 대응 |
|-----------|------|
| 테스트 파일 하드코딩 IP | `[TEST FILE]` 태깅 + 프롬프트 규칙 |
| N+1 쿼리 오판 | ORM 패턴 명시적 예외 |
| 비동기→동기 오판 | AsyncClient/await 패턴 예외 |
| 존재하지 않는 코드 추론 | line+evidence 필수, 80% 확신 기준 |

## Test plan
- [x] 테스트 21건 신규 추가 (isTestFile 5, parseHaikuOutput 7, buildScanPrompt 6, issueKey 3)
- [x] 전체 테스트 76건 통과
- [x] TypeScript 타입 체크 통과

🤖 Generated with [Claude Code](https://claude.com/claude-code)