### PR TITLE
refactor: prompt token optimization — condensed mode for repeat invocations

### DIFF
--- a/src/orchestrator/prompt-builder.ts
+++ b/src/orchestrator/prompt-builder.ts
@@ -407,9 +407,7 @@ export async function buildTeamPrompt(
   // Conditionally load New Agent Protocol only when relevant
   const messageContent = invocation.message.content;
   const isNewAgentEvent = messageContent.includes('[신규 모코코 입장]')
-    || messageContent.includes('[New Agent Joined]')
-    || messageContent.includes('신규')
-    || messageContent.includes('입장');
+    || messageContent.includes('[New Agent Joined]');
   let newAgentProtocol = '';
   if (isNewAgentEvent) {
     const rawProtocol = readCached(path.resolve(ws, 'prompts/new-agent-protocol.md'));


### PR DESCRIPTION
## Summary
- **Phase 1**: 팀 프롬프트 `Who You Are` 섹션 4~8줄 → 1줄로 축약, "NEVER merge PRs" 규칙 `shared-rules.md`로 통합
- **Phase 2**: `prompt-builder.ts` — short-term memory 유무로 첫 호출/재호출 판별, Discord Commands·Memory 섹션 축약 버전 분리, New Agent Protocol 조건부 로드
- 예상 절감: 재호출 시 요청당 ~3,400 토큰 (37%) 절감

## Changes
| 파일 | 변경 |
|------|------|
| `src/orchestrator/prompt-builder.ts` | `isFirstInvocation` 플래그 도입, `buildMemorySection`/`buildDiscordCommandsSection`에 축약 모드 추가, New Agent Protocol 조건부 로드 |
| `prompts/backend.md` | Who You Are 8줄 → 1줄 |
| `prompts/review.md` | Who You Are 9줄 → 1줄 |
| `prompts/frontend.md` | Who You Are 9줄 → 1줄 |
| `prompts/planning.md` | Who You Are 8줄 → 1줄 |
| `prompts/design.md` | Who You Are 8줄 → 1줄 |
| `prompts/shared-rules.md` | "NEVER merge PRs" 통합, New Agent Protocol 분리 |
| `prompts/new-agent-protocol.md` | 신규 — 조건부 로드용 분리 파일 |

**Note**: `prompts/` 디렉토리는 `.gitignore`에 포함되어 git 추적 대상이 아닙니다. 프롬프트 파일 변경은 로컬에서 즉시 반영됩니다.

## Test plan
- [ ] 봇 재시작 후 첫 호출 시 전체 Discord Commands 가이드 출력 확인
- [ ] 두 번째 이후 호출 시 축약 버전 출력 확인
- [ ] `[신규 모코코 입장]` 메시지에서만 New Agent Protocol 포함 확인
- [ ] 일반 메시지에서 New Agent Protocol 미포함 확인
- [ ] TypeScript 빌드 에러 없음

🤖 Generated with [Claude Code](https://claude.com/claude-code)