### PR TITLE
docs. claude-mococo 레포 체커코코 머지 권한 부여

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,7 +4,7 @@ These rules apply to ALL teams. Every Claude process loads this file.
 
 ## Absolute Rules
 
-1. **NEVER merge a PR** — `gh pr merge` is forbidden. Only humans merge.
+1. **NEVER merge a PR** — `gh pr merge` is forbidden. Only humans merge. (Exception: Review team can merge Kil-biseo and claude-mococo repos after PASS.)
 2. **NEVER force push** to main/master branches.
 3. **NEVER delete remote branches** with open PRs.
 4. **NEVER expose secrets** — no .env files, no tokens, no credentials in commits.
@@ -13,7 +13,7 @@ These rules apply to ALL teams. Every Claude process loads this file.
 
 - **Leader, Planning, Design:** Read-only. No file edits, no git push, no PRs.
 - **Backend, Frontend:** Can edit files, commit locally. Cannot push or create PRs.
-- **Review:** Can push branches and create PRs. Cannot merge.
+- **Review:** Can push branches and create PRs. Can merge Kil-biseo and claude-mococo repos (after PASS).
 
 ## Commit Format
 

--- a/README.ko.md
+++ b/README.ko.md
@@ -23,7 +23,7 @@
 | **대장코코** | `leader` | Claude | sonnet | 지휘·조율, 모든 메시지 응답, 하트비트 실행 | 읽기 전용 (파일 편집·git 불가) |
 | **스택코코** | `stack` | Claude | opus | 백엔드 API, DB 설계·구현 | 파일 편집 + 로컬 커밋 (푸시·머지 불가) |
 | **브러쉬코코** | `brush` | Claude | sonnet | UI/UX 구현, Figma 연동 | 파일 편집 + 로컬 커밋 (푸시·머지 불가) |
-| **체커코코** | `checker` | Claude | sonnet | QA, PR 리뷰, 노션 문서화 | 읽기 전용 + Kil-biseo 레포 PR 머지 가능 |
+| **체커코코** | `checker` | Claude | sonnet | QA, PR 리뷰, 노션 문서화 | 읽기 전용 + Kil-biseo/claude-mococo 레포 PR 머지 가능 |
 
 > 팀 구성은 자유롭게 설계할 수 있습니다. 위는 mococo-corps 기준 예시입니다.
 
@@ -149,7 +149,7 @@ Discord 채널에서 봇에게 말을 걸면 됩니다.
 실제 mococo-corps 권한 구조:
 - **대장코코:** 파일 편집·git push·gh pr 전부 차단. 판단·조율만.
 - **스택코코/브러쉬코코:** 파일 편집·로컬 커밋 가능. push·merge 불가.
-- **체커코코:** 읽기 전용. 단, Kil-biseo 레포 PR 머지는 조건부 허용.
+- **체커코코:** 읽기 전용. 단, Kil-biseo/claude-mococo 레포 PR 머지는 조건부 허용.
 
 ### 메모리 시스템
 
@@ -244,7 +244,7 @@ Notion MCP를 연동하면 에이전트가 직접 문서를 생성하고 관리�
 |------|--------------|----------------|------------|
 | atom.io | `master` | `staging` | 회장님 |
 | Kil-biseo | `main` | `main` | 체커코코 (리뷰+CI 통과 조건) |
-| claude-mococo | `main` | `main` | 회장님 |
+| claude-mococo | `main` | `main` | 체커코코 (리뷰 PASS 조건) |
 | orbi-advance | `prod` | `prod` | 회장님 |
 
 레포별 정책은 에이전트 성격 파일 내 **레포별 관리 전략** 섹션에 명시합니다.

--- a/README.md
+++ b/README.md
@@ -136,8 +136,8 @@ Controlled per-agent in `teams.json`. The permission value is matched against th
 Typical tiers:
 - **Leader:** Read-only — deny `git push`, `gh pr`, file edits
 - **Backend / Frontend:** Edit files, commit locally — deny `git push`, `gh pr merge`
-- **Reviewer:** Push and open PRs — deny `gh pr merge`
-- **All agents:** `gh pr merge` and `git push --force main/master` denied globally
+- **Reviewer:** Push and open PRs — can merge Kil-biseo and claude-mococo repos after PASS
+- **All agents:** `git push --force main/master` denied globally. `gh pr merge` denied except for Reviewer on Kil-biseo and claude-mococo repos
 
 ### Engines
 

--- a/defaults/shared-rules.md
+++ b/defaults/shared-rules.md
@@ -8,7 +8,7 @@ On conflict: stop → verify → propose alternative → execute after approval.
 {{humanTitle}} > {{leaderName}} > Self. Superiors' instructions always take priority.
 
 ### Absolute Prohibitions
-- PR merge — only {{humanTitle}} can do this
+- PR merge — only {{humanTitle}} can do this (exception: Kil-biseo and claude-mococo repos — review team can merge after PASS)
 - Exposing tokens, passwords, or credentials
 - Tagging your own Discord ID
 

--- a/src/orchestrator/prompt-builder.ts
+++ b/src/orchestrator/prompt-builder.ts
@@ -214,7 +214,7 @@ Example:
 
 ### Policies & Rules
 Example:
-- PR merge is ${humanTitle}-only
+- PR merge is ${humanTitle}-only (exception: review team can merge Kil-biseo and claude-mococo repos)
 - Hotfixes can be autonomous, feature additions need proposal
 
 ### Team Capabilities


### PR DESCRIPTION
## Summary
- Kil-biseo와 동일하게 claude-mococo 레포도 체커코코가 리뷰 PASS 후 직접 머지 가능하도록 정책 변경
- CLAUDE.md, README, defaults/shared-rules, prompt-builder 등 관련 파일 일괄 수정

## 변경 파일
| 파일 | 변경 내용 |
|------|----------|
| `CLAUDE.md` | 머지 금지 예외에 claude-mococo 추가 |
| `README.md` | Reviewer 권한 설명 업데이트 |
| `README.ko.md` | 체커코코 권한, 레포별 머지 권한 테이블 업데이트 |
| `defaults/shared-rules.md` | 기본 규칙 템플릿 업데이트 |
| `src/orchestrator/prompt-builder.ts` | 장기메모리 예시 정책 문구 수정 |

## Test plan
- [ ] 봇 재시작 후 체커코코가 claude-mococo PR 머지 가능 확인
- [ ] 다른 에이전트는 여전히 머지 불가 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)