### PR TITLE
feat: 에이전트 스트레스 시스템 + 하트비트 TaskRegistry 전환

### DIFF
--- a/src/bot/__tests__/heartbeat-periodic.test.ts
+++ b/src/bot/__tests__/heartbeat-periodic.test.ts
@@ -18,6 +18,11 @@ vi.mock('../../teams/dispatch-ledger.js', () => ({
 }));
 vi.mock('../../teams/context.js', () => ({ addMessage: vi.fn() }));
 vi.mock('../client.js', () => ({ newChain: vi.fn() }));
+vi.mock('../heartbeat-tasks.js', () => ({ toHeartbeatTasks: vi.fn(() => []) }));
+vi.mock('../stress-tracker.js', () => ({ decayAll: vi.fn() }));
+
+// Force md-based parsing for these tests (testing the md parser, not the TaskRegistry)
+process.env.HEARTBEAT_SOURCE = 'md';
 
 import { parseHeartbeatMd, getDueHeartbeatTasks, shouldSuppressHeartbeat } from '../inbox-compactor.js';
 import { isBusy, isQueued } from '../../teams/concurrency.js';

--- a/src/bot/__tests__/heartbeat-tasks.test.ts
+++ b/src/bot/__tests__/heartbeat-tasks.test.ts
@@ -1,0 +1,84 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import {
+  getAllTasks,
+  getTasksBySchedule,
+  addRuntimeTask,
+  removeRuntimeTask,
+  listRuntimeTasks,
+  toHeartbeatTasks,
+  _resetRuntimeForTesting,
+} from '../heartbeat-tasks.js';
+
+describe('heartbeat-tasks TaskRegistry', () => {
+  beforeEach(() => {
+    _resetRuntimeForTesting();
+  });
+
+  // TC-11: getDueHeartbeatTasks('daily') returns daily tasks
+  it('TC-11: getTasksBySchedule returns only tasks of given schedule', () => {
+    const daily = getTasksBySchedule('daily');
+    expect(daily.length).toBeGreaterThan(0);
+    expect(daily.every(t => t.schedule === 'daily')).toBe(true);
+  });
+
+  // TC-13: Task count matches heartbeat.md
+  it('TC-13: all static tasks are present (5 daily + 3 weekly + 4 periodic = 12)', () => {
+    const all = getAllTasks();
+    expect(all.length).toBe(12);
+
+    expect(getTasksBySchedule('daily').length).toBe(5);
+    expect(getTasksBySchedule('weekly').length).toBe(3);
+    expect(getTasksBySchedule('periodic').length).toBe(4);
+    expect(getTasksBySchedule('hourly').length).toBe(0);
+    expect(getTasksBySchedule('on-demand').length).toBe(0);
+  });
+
+  it('toHeartbeatTasks returns backward-compatible format', () => {
+    const tasks = toHeartbeatTasks();
+    expect(tasks.length).toBe(12);
+    expect(tasks[0]).toHaveProperty('section');
+    expect(tasks[0]).toHaveProperty('content');
+    expect(tasks[0]).toHaveProperty('assignee');
+  });
+
+  it('addRuntimeTask adds a task visible in getAllTasks', () => {
+    const task = addRuntimeTask('테스트 작업', 'hourly', '스택코코');
+    expect(task.id).toMatch(/^runtime-/);
+
+    const all = getAllTasks();
+    expect(all.length).toBe(13); // 12 static + 1 runtime
+
+    const hourly = getTasksBySchedule('hourly');
+    expect(hourly.length).toBe(1);
+    expect(hourly[0].description).toBe('테스트 작업');
+  });
+
+  it('removeRuntimeTask removes the task', () => {
+    const task = addRuntimeTask('삭제 대상', 'daily');
+    expect(getAllTasks().length).toBe(13);
+
+    const removed = removeRuntimeTask(task.id);
+    expect(removed).toBe(true);
+    expect(getAllTasks().length).toBe(12);
+  });
+
+  it('removeRuntimeTask returns false for non-existent id', () => {
+    expect(removeRuntimeTask('nonexistent')).toBe(false);
+  });
+
+  it('listRuntimeTasks returns only runtime tasks', () => {
+    addRuntimeTask('런타임 1', 'periodic');
+    addRuntimeTask('런타임 2', 'daily');
+
+    const runtime = listRuntimeTasks();
+    expect(runtime.length).toBe(2);
+    expect(runtime.every(t => t.id.startsWith('runtime-'))).toBe(true);
+  });
+
+  // TC-15: heartbeat.md existence doesn't affect TaskRegistry
+  it('TC-15: TaskRegistry operates independently of heartbeat.md', () => {
+    // TaskRegistry doesn't read files — it's purely code-defined
+    const tasks = getAllTasks();
+    expect(tasks.length).toBe(12);
+  });
+});

--- a/src/bot/__tests__/stress-tracker.test.ts
+++ b/src/bot/__tests__/stress-tracker.test.ts
@@ -1,0 +1,207 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import fs from 'node:fs';
+import path from 'node:path';
+import os from 'node:os';
+
+// Mock modules that stress-tracker imports
+vi.mock('../../teams/concurrency.js', () => ({
+  isBusy: vi.fn(() => false),
+  isQueued: vi.fn(() => false),
+}));
+
+vi.mock('../../teams/dispatch-ledger.js', () => ({
+  ledger: { getUnresolved: vi.fn(() => []) },
+}));
+
+vi.mock('../episode-writer.js', () => ({
+  loadRecentEpisodes: vi.fn(() => ''),
+}));
+
+vi.mock('../../utils/fs.js', () => ({
+  atomicWriteSync: (filePath: string, content: string) => {
+    const dir = path.dirname(filePath);
+    fs.mkdirSync(dir, { recursive: true });
+    fs.writeFileSync(filePath, content);
+  },
+}));
+
+import {
+  updateStress,
+  getStressLevel,
+  getStressScore,
+  decayAll,
+  loadState,
+  getStressModifier,
+  shouldSendLevel3Alert,
+  markLevel3AlertSent,
+  _resetForTesting,
+} from '../stress-tracker.js';
+import type { StressProfile } from '../../types.js';
+
+describe('stress-tracker', () => {
+  let tmpDir: string;
+
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'stress-test-'));
+    _resetForTesting();
+  });
+
+  afterEach(() => {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  // TC-01: Initial score=0, task_failed → score=20
+  it('TC-01: task_failed event increases score by 20', () => {
+    const state = updateStress(tmpDir, 'team-a', 'task_failed');
+    expect(state.score).toBe(20);
+  });
+
+  // TC-02: score=100, task_complete → score=85 (clamped)
+  it('TC-02: task_complete from max score decreases to 85', () => {
+    // Build up to 100
+    updateStress(tmpDir, 'team-b', 'task_failed'); // 20
+    updateStress(tmpDir, 'team-b', 'task_failed'); // 40
+    updateStress(tmpDir, 'team-b', 'task_failed'); // 60
+    updateStress(tmpDir, 'team-b', 'task_failed'); // 80
+    updateStress(tmpDir, 'team-b', 'task_failed'); // 100
+    expect(getStressScore(tmpDir, 'team-b')).toBe(100);
+
+    const state = updateStress(tmpDir, 'team-b', 'task_complete');
+    expect(state.score).toBe(85);
+  });
+
+  // TC-03: queue_added with sensitivity=1.0 → +10 each, max cap at 100
+  it('TC-03: queue_added events accumulate with cap', () => {
+    updateStress(tmpDir, 'team-c', 'queue_added'); // 10
+    updateStress(tmpDir, 'team-c', 'queue_added'); // 20
+    updateStress(tmpDir, 'team-c', 'queue_added'); // 30
+    expect(getStressScore(tmpDir, 'team-c')).toBe(30);
+  });
+
+  // TC-04: getStressLevel returns correct levels for boundary values
+  it('TC-04: getStressLevel returns correct levels', () => {
+    expect(getStressLevel(tmpDir, 'level-test')).toBe(0); // score=0
+
+    updateStress(tmpDir, 'level-test', 'queue_added'); // 10
+    updateStress(tmpDir, 'level-test', 'queue_added'); // 20
+    expect(getStressLevel(tmpDir, 'level-test')).toBe(0); // 20 ≤ 25
+
+    updateStress(tmpDir, 'level-test', 'queue_added'); // 30
+    expect(getStressLevel(tmpDir, 'level-test')).toBe(1); // 30 > 25
+
+    updateStress(tmpDir, 'level-test', 'task_failed'); // 50
+    expect(getStressLevel(tmpDir, 'level-test')).toBe(1); // 50 ≤ 50... exactly 50
+
+    updateStress(tmpDir, 'level-test', 'queue_added'); // 60
+    expect(getStressLevel(tmpDir, 'level-test')).toBe(2); // 60 > 50
+
+    updateStress(tmpDir, 'level-test', 'review_rework'); // 75
+    expect(getStressLevel(tmpDir, 'level-test')).toBe(2); // 75 = threshold
+
+    updateStress(tmpDir, 'level-test', 'queue_added'); // 85
+    expect(getStressLevel(tmpDir, 'level-test')).toBe(3); // 85 > 75
+  });
+
+  // TC-05: decay applies score * 0.9
+  it('TC-05: decayAll applies 0.9 factor', () => {
+    updateStress(tmpDir, 'decay-test', 'task_failed'); // 20
+    updateStress(tmpDir, 'decay-test', 'task_failed'); // 40
+    updateStress(tmpDir, 'decay-test', 'task_failed'); // 60
+    updateStress(tmpDir, 'decay-test', 'task_failed'); // 80
+    updateStress(tmpDir, 'decay-test', 'task_failed'); // 100
+    expect(getStressScore(tmpDir, 'decay-test')).toBe(100);
+
+    decayAll(tmpDir, ['decay-test']);
+    expect(getStressScore(tmpDir, 'decay-test')).toBe(90); // 100 * 0.9
+
+    decayAll(tmpDir, ['decay-test']);
+    expect(getStressScore(tmpDir, 'decay-test')).toBe(81); // 90 * 0.9 = 81
+  });
+
+  // TC-06: persistence — write and read back
+  it('TC-06: state persists to file and restores', () => {
+    updateStress(tmpDir, 'persist-test', 'task_failed'); // 20
+    updateStress(tmpDir, 'persist-test', 'task_failed'); // 40
+
+    // Reset in-memory cache
+    _resetForTesting();
+
+    // Reload from file
+    const state = loadState(tmpDir, 'persist-test');
+    expect(state.score).toBe(40);
+    expect(state.teamId).toBe('persist-test');
+  });
+
+  // TC-09: sensitivity=2.0 doubles the delta
+  it('TC-09: sensitivity multiplier applied correctly', () => {
+    const state = updateStress(tmpDir, 'sens-test', 'task_failed', 2.0);
+    expect(state.score).toBe(40); // 20 * 2.0
+
+    const state2 = updateStress(tmpDir, 'sens-test', 'task_complete', 2.0);
+    expect(state2.score).toBe(10); // 40 + (-15 * 2.0) = 10
+  });
+
+  // Stress modifier text
+  it('TC-07: Level 0 returns empty modifier', () => {
+    const profile: StressProfile = {
+      sensitivity: 1.0,
+      modifiers: { level1: 'busy', level2: 'stressed', level3: 'overloaded' },
+    };
+    const result = getStressModifier(tmpDir, 'mod-test', profile);
+    expect(result).toBe('');
+  });
+
+  it('TC-08: Level 2 returns correct modifier text', () => {
+    const profile: StressProfile = {
+      sensitivity: 1.0,
+      modifiers: { level1: 'busy mode', level2: 'stressed mode', level3: 'overloaded mode' },
+    };
+    // Push to level 2 (score > 50)
+    updateStress(tmpDir, 'mod-test-2', 'task_failed'); // 20
+    updateStress(tmpDir, 'mod-test-2', 'task_failed'); // 40
+    updateStress(tmpDir, 'mod-test-2', 'review_rework'); // 55
+
+    const result = getStressModifier(tmpDir, 'mod-test-2', profile);
+    expect(result).toContain('## Current Mood');
+    expect(result).toContain('stressed mode');
+    expect(result).toContain('레벨: 2/3');
+  });
+
+  // Level 3 alert cooldown
+  it('TC-10: Level 3 alert respects cooldown', () => {
+    // Push to level 3
+    updateStress(tmpDir, 'alert-test', 'task_failed'); // 20
+    updateStress(tmpDir, 'alert-test', 'task_failed'); // 40
+    updateStress(tmpDir, 'alert-test', 'task_failed'); // 60
+    updateStress(tmpDir, 'alert-test', 'task_failed'); // 80
+
+    expect(shouldSendLevel3Alert(tmpDir, 'alert-test')).toBe(true);
+
+    markLevel3AlertSent(tmpDir, 'alert-test');
+    expect(shouldSendLevel3Alert(tmpDir, 'alert-test')).toBe(false);
+  });
+
+  // Score never goes below 0
+  it('score never goes below 0', () => {
+    updateStress(tmpDir, 'floor-test', 'positive_feedback'); // -10 → 0
+    expect(getStressScore(tmpDir, 'floor-test')).toBe(0);
+
+    updateStress(tmpDir, 'floor-test', 'task_complete'); // -15 → 0
+    expect(getStressScore(tmpDir, 'floor-test')).toBe(0);
+  });
+
+  // No profile returns empty modifier
+  it('getStressModifier returns empty when no profile', () => {
+    updateStress(tmpDir, 'no-profile', 'task_failed');
+    updateStress(tmpDir, 'no-profile', 'task_failed');
+    updateStress(tmpDir, 'no-profile', 'task_failed');
+    updateStress(tmpDir, 'no-profile', 'task_failed');
+    expect(getStressModifier(tmpDir, 'no-profile', undefined)).toBe('');
+  });
+
+  // Decay on zero score is no-op
+  it('decay on zero score remains zero', () => {
+    decayAll(tmpDir, ['zero-test']);
+    expect(getStressScore(tmpDir, 'zero-test')).toBe(0);
+  });
+});

--- a/src/bot/client.ts
+++ b/src/bot/client.ts
@@ -18,6 +18,7 @@ import { startMemoryConsolidator, checkSizeBasedConsolidation } from './memory-c
 import { startImprovementScanner } from './improvement-scanner.js';
 import { writeEpisode } from './episode-writer.js';
 import { verifyPRStatuses } from '../utils/github-status.js';
+import { updateStress, shouldSendLevel3Alert, markLevel3AlertSent } from './stress-tracker.js';
 import type { TeamsConfig, TeamConfig, EnvConfig, ConversationMessage, ChainContext } from '../types.js';
 
 // ---------------------------------------------------------------------------
@@ -834,6 +835,8 @@ export async function handleTeamInvocation(
   }
 
   if (isBusy(team.id)) {
+    // Stress: queue pressure
+    updateStress(config.workspacePath, team.id, 'queue_added', team.stressProfile?.sensitivity ?? 1.0);
     await waitForFree(team.id);
   }
 
@@ -972,6 +975,27 @@ async function executeInvocation(
 
     // Size-based consolidation trigger
     checkSizeBasedConsolidation(team.id, team.name, config);
+
+    // Stress: detect positive feedback in trigger message
+    const POSITIVE_KEYWORDS = ['좋아', 'PASS', '잘했', '수고', '완료', '승인', '좋습니다', '잘 했'];
+    if (POSITIVE_KEYWORDS.some(kw => triggerMsg.content.includes(kw))) {
+      updateStress(config.workspacePath, team.id, 'positive_feedback', team.stressProfile?.sensitivity ?? 1.0);
+    }
+
+    // Stress: Level 3 overload alert to leader
+    if (shouldSendLevel3Alert(config.workspacePath, team.id)) {
+      const leaderTeam = Object.values(config.teams).find(t => t.isLeader);
+      if (leaderTeam) {
+        markLevel3AlertSent(config.workspacePath, team.id);
+        await appendToInbox(
+          leaderTeam.id,
+          'System',
+          `[과부하 알림] ${team.name} 스트레스 레벨 3 도달. 작업 재조정이 필요합니다.`,
+          config.workspacePath,
+          channelId,
+        ).catch(() => {});
+      }
+    }
 
     // Resolve any pending dispatch records (this team reported back)
     ledger.resolve(team.id, mentionedTeams.map(t => t.id));

--- a/src/bot/heartbeat-tasks.ts
+++ b/src/bot/heartbeat-tasks.ts
@@ -1,0 +1,173 @@
+// ---------------------------------------------------------------------------
+// Heartbeat TaskRegistry — replaces heartbeat.md with type-safe task definitions
+// ---------------------------------------------------------------------------
+
+export type HeartbeatSchedule = 'daily' | 'weekly' | 'hourly' | 'periodic' | 'on-demand';
+
+export interface HeartbeatTaskDef {
+  id: string;
+  description: string;
+  schedule: HeartbeatSchedule;
+  assignee: string | null;
+  enabled: boolean;
+}
+
+// ---------------------------------------------------------------------------
+// Static task registry — migrated from heartbeat.md
+// ---------------------------------------------------------------------------
+
+const staticTasks: HeartbeatTaskDef[] = [
+  // --- Daily ---
+  {
+    id: 'daily-closed-pr-issues',
+    description: '각 레포 closed PR 목록 확인 → 연결된 이슈 중 close 가능한 이슈 close 처리',
+    schedule: 'daily',
+    assignee: '체커코코',
+    enabled: true,
+  },
+  {
+    id: 'daily-ci-failure-check',
+    description: '각 레포 오픈 PR 중 CI 실패 건 확인 → 담당 코코에게 알림',
+    schedule: 'daily',
+    assignee: '체커코코',
+    enabled: true,
+  },
+  {
+    id: 'daily-stale-pr-review',
+    description: '오픈 PR 중 48시간 이상 리뷰 없는 건 확인 → 대장코코에게 보고',
+    schedule: 'daily',
+    assignee: '체커코코',
+    enabled: true,
+  },
+  {
+    id: 'daily-calendar-summary',
+    description: 'Google Calendar 오늘 일정 확인 → 하루 일정 요약 보고',
+    schedule: 'daily',
+    assignee: '대장코코',
+    enabled: true,
+  },
+  {
+    id: 'daily-new-issues-assignment',
+    description: '각 레포(claude-mococo, Kil-biseo) 새로 오픈된 이슈 확인 → 미할당 이슈 자동 할당 판단',
+    schedule: 'daily',
+    assignee: '대장코코',
+    enabled: true,
+  },
+
+  // --- Weekly ---
+  {
+    id: 'weekly-completed-summary',
+    description: '지난 주 완료 작업(머지된 PR, close된 이슈) 요약 → 노션 문서화',
+    schedule: 'weekly',
+    assignee: '체커코코',
+    enabled: true,
+  },
+  {
+    id: 'weekly-stale-issues-review',
+    description: '7일 이상 미해결 오픈 이슈 목록 확인 → 우선순위 재검토 및 필요 시 담당 코코 재할당',
+    schedule: 'weekly',
+    assignee: '대장코코',
+    enabled: true,
+  },
+  {
+    id: 'weekly-stale-branches',
+    description: '각 레포 3주 이상 미활동 브랜치 목록 확인 → 정리 필요 여부 대장코코에게 보고',
+    schedule: 'weekly',
+    assignee: '체커코코',
+    enabled: true,
+  },
+
+  // --- Periodic ---
+  {
+    id: 'periodic-server-health',
+    description: 'mococo-corps 서버 상태 확인 (포트 9876 응답 여부) → 이상 시 즉시 대장코코 에스컬레이션',
+    schedule: 'periodic',
+    assignee: '대장코코',
+    enabled: true,
+  },
+  {
+    id: 'periodic-code-analysis',
+    description: 'Kil-biseo/claude-mococo 레포지토리 코드 분석 → 개선점 GitHub ISSUE 등록',
+    schedule: 'periodic',
+    assignee: '체커코코',
+    enabled: true,
+  },
+  {
+    id: 'periodic-feature-planning',
+    description: 'Kil-biseo/claude-mococo 서비스 분석 기반 신규 기능 기획 → 노션 문서화 → GitHub 이슈 등록 (이슈 본문에 노션 URL 포함) → 팀 자율 우선순위 결정 → 개발 착수 배정',
+    schedule: 'periodic',
+    assignee: '체커코코',
+    enabled: true,
+  },
+  {
+    id: 'periodic-pr-review-merge',
+    description: '스택코코/브러쉬코코 작업 완료 PR 확인 → 코드리뷰 → 수정 요청 → CI 확인 → 모두 통과 시 PR 코멘트 작성 + 머지 실행 (Kil-biseo 한정) → 머지 시점 논블로킹 이슈 발견 시 이슈 동시 등록',
+    schedule: 'periodic',
+    assignee: '체커코코',
+    enabled: true,
+  },
+];
+
+// Runtime tasks added via Discord command (transient — lost on restart)
+const runtimeTasks: HeartbeatTaskDef[] = [];
+let runtimeIdCounter = 0;
+
+// ---------------------------------------------------------------------------
+// Public API
+// ---------------------------------------------------------------------------
+
+export function getAllTasks(): HeartbeatTaskDef[] {
+  return [...staticTasks, ...runtimeTasks].filter(t => t.enabled);
+}
+
+export function getTasksBySchedule(schedule: HeartbeatSchedule): HeartbeatTaskDef[] {
+  return getAllTasks().filter(t => t.schedule === schedule);
+}
+
+export function addRuntimeTask(
+  description: string,
+  schedule: HeartbeatSchedule,
+  assignee: string | null = null,
+): HeartbeatTaskDef {
+  const task: HeartbeatTaskDef = {
+    id: `runtime-${++runtimeIdCounter}`,
+    description,
+    schedule,
+    assignee,
+    enabled: true,
+  };
+  runtimeTasks.push(task);
+  return task;
+}
+
+export function removeRuntimeTask(id: string): boolean {
+  const idx = runtimeTasks.findIndex(t => t.id === id);
+  if (idx === -1) return false;
+  runtimeTasks.splice(idx, 1);
+  return true;
+}
+
+export function listRuntimeTasks(): HeartbeatTaskDef[] {
+  return [...runtimeTasks];
+}
+
+/**
+ * Convert TaskRegistry tasks to the HeartbeatTask format
+ * used by inbox-compactor for backward compatibility.
+ */
+export function toHeartbeatTasks(): { section: HeartbeatSchedule; content: string; assignee: string | null }[] {
+  return getAllTasks().map(t => ({
+    section: t.schedule,
+    content: t.description,
+    assignee: t.assignee,
+  }));
+}
+
+// ---------------------------------------------------------------------------
+// Reset (for testing)
+// ---------------------------------------------------------------------------
+
+export function _resetRuntimeForTesting(): void {
+  runtimeTasks.length = 0;
+  runtimeIdCounter = 0;
+}

--- a/src/bot/inbox-compactor.ts
+++ b/src/bot/inbox-compactor.ts
@@ -6,6 +6,8 @@ import { isBusy, isQueued } from '../teams/concurrency.js';
 import { ledger } from '../teams/dispatch-ledger.js';
 import { addMessage } from '../teams/context.js';
 import { newChain } from './client.js';
+import { toHeartbeatTasks } from './heartbeat-tasks.js';
+import { decayAll } from './stress-tracker.js';
 import type { TeamsConfig, TeamConfig, EnvConfig, ConversationMessage, ChainContext } from '../types.js';
 
 /** Check if a team is currently busy or queued (not available for new work). */
@@ -101,7 +103,9 @@ function writeHeartbeatState(ws: string, state: HeartbeatState): void {
 }
 
 export function getDueHeartbeatTasks(ws: string, config?: TeamsConfig): HeartbeatTask[] {
-  const allTasks = parseHeartbeatMd(ws);
+  // Use TaskRegistry (code-defined tasks) with fallback to heartbeat.md
+  const useRegistry = process.env.HEARTBEAT_SOURCE !== 'md';
+  const allTasks = useRegistry ? toHeartbeatTasks() : parseHeartbeatMd(ws);
   if (allTasks.length === 0) return [];
 
   const state = readHeartbeatState(ws);
@@ -290,9 +294,12 @@ async function leaderHeartbeat(
   try {
     const leaderTeam = Object.values(config.teams).find(t => t.isLeader);
     if (!leaderTeam) return;
-    if (isOccupied(leaderTeam.id)) return;
 
+    // Stress decay — runs every heartbeat cycle regardless of leader availability
     const ws = config.workspacePath;
+    decayAll(ws, Object.keys(config.teams));
+
+    if (isOccupied(leaderTeam.id)) return;
     const inboxPath = path.resolve(ws, '.mococo/inbox', `${leaderTeam.id}.md`);
 
     // Gather context

--- a/src/bot/stress-tracker.ts
+++ b/src/bot/stress-tracker.ts
@@ -1,0 +1,258 @@
+import fs from 'node:fs';
+import path from 'node:path';
+import { atomicWriteSync } from '../utils/fs.js';
+import { isBusy, isQueued } from '../teams/concurrency.js';
+import { ledger } from '../teams/dispatch-ledger.js';
+import { loadRecentEpisodes } from './episode-writer.js';
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+export type StressEvent =
+  | 'task_complete'
+  | 'task_failed'
+  | 'queue_added'
+  | 'positive_feedback'
+  | 'dispatch_resolved'
+  | 'review_rework';
+
+export interface StressProfile {
+  sensitivity: number; // 0.5~2.0, default 1.0
+  modifiers: {
+    level1: string;
+    level2: string;
+    level3: string;
+  };
+}
+
+export interface StressState {
+  teamId: string;
+  score: number;      // 0~100
+  level: number;      // 0~3
+  lastUpdated: number; // Unix ms
+  lastLevel3AlertAt: number; // Unix ms — for cooldown
+}
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+const SCORE_MIN = 0;
+const SCORE_MAX = 100;
+const LEVEL_THRESHOLDS = [25, 50, 75] as const; // 0~25=L0, 26~50=L1, 51~75=L2, 76~100=L3
+const DECAY_FACTOR = 0.9; // 10% decay per hour
+const LEVEL3_ALERT_COOLDOWN_MS = 10 * 60_000; // 10 minutes
+
+// Event score deltas (before sensitivity multiplier)
+const EVENT_DELTAS: Record<StressEvent, number> = {
+  task_complete: -15,
+  task_failed: +20,
+  queue_added: +10,
+  positive_feedback: -10,
+  dispatch_resolved: -5,
+  review_rework: +15,
+};
+
+// ---------------------------------------------------------------------------
+// State store (in-memory + file persistence)
+// ---------------------------------------------------------------------------
+
+const stressStates = new Map<string, StressState>();
+
+function clampScore(score: number): number {
+  return Math.max(SCORE_MIN, Math.min(SCORE_MAX, Math.round(score)));
+}
+
+function scoreToLevel(score: number): number {
+  if (score > LEVEL_THRESHOLDS[2]) return 3;
+  if (score > LEVEL_THRESHOLDS[1]) return 2;
+  if (score > LEVEL_THRESHOLDS[0]) return 1;
+  return 0;
+}
+
+// ---------------------------------------------------------------------------
+// Persistence
+// ---------------------------------------------------------------------------
+
+function stressDir(ws: string): string {
+  return path.resolve(ws, '.mococo/stress');
+}
+
+function stressFilePath(ws: string, teamId: string): string {
+  return path.resolve(stressDir(ws), `${teamId}.json`);
+}
+
+function saveState(ws: string, state: StressState): void {
+  const dir = stressDir(ws);
+  try {
+    fs.mkdirSync(dir, { recursive: true });
+    atomicWriteSync(stressFilePath(ws, state.teamId), JSON.stringify(state, null, 2));
+  } catch (err) {
+    console.error(`[stress-tracker] Failed to save state for ${state.teamId}: ${err instanceof Error ? err.message : err}`);
+  }
+}
+
+export function loadState(ws: string, teamId: string): StressState {
+  const cached = stressStates.get(teamId);
+  if (cached) return cached;
+
+  const filePath = stressFilePath(ws, teamId);
+  try {
+    const raw = fs.readFileSync(filePath, 'utf-8');
+    const data = JSON.parse(raw) as StressState;
+    // Validate essential fields
+    if (typeof data.score !== 'number' || typeof data.teamId !== 'string') {
+      throw new Error('Invalid stress state format');
+    }
+    data.level = scoreToLevel(data.score);
+    stressStates.set(teamId, data);
+    return data;
+  } catch {
+    // File missing or corrupted — start fresh
+    const fresh: StressState = {
+      teamId,
+      score: 0,
+      level: 0,
+      lastUpdated: Date.now(),
+      lastLevel3AlertAt: 0,
+    };
+    stressStates.set(teamId, fresh);
+    return fresh;
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Core API
+// ---------------------------------------------------------------------------
+
+export function updateStress(
+  ws: string,
+  teamId: string,
+  event: StressEvent,
+  sensitivity = 1.0,
+): StressState {
+  const state = loadState(ws, teamId);
+  const delta = EVENT_DELTAS[event] * sensitivity;
+  state.score = clampScore(state.score + delta);
+  state.level = scoreToLevel(state.score);
+  state.lastUpdated = Date.now();
+  stressStates.set(teamId, state);
+  saveState(ws, state);
+  return state;
+}
+
+export function getStressLevel(ws: string, teamId: string): number {
+  return loadState(ws, teamId).level;
+}
+
+export function getStressScore(ws: string, teamId: string): number {
+  return loadState(ws, teamId).score;
+}
+
+/**
+ * Apply time-based decay: score *= DECAY_FACTOR (10% reduction).
+ * Called from heartbeat cycle (~3 min interval).
+ */
+export function decayAll(ws: string, teamIds: string[]): void {
+  for (const teamId of teamIds) {
+    const state = loadState(ws, teamId);
+    if (state.score === 0) continue;
+    state.score = clampScore(state.score * DECAY_FACTOR);
+    state.level = scoreToLevel(state.score);
+    state.lastUpdated = Date.now();
+    stressStates.set(teamId, state);
+    saveState(ws, state);
+  }
+}
+
+/**
+ * Calculate contextual stress from current system state.
+ * Called before building prompt to capture queue depth, busy time, etc.
+ */
+export function evaluateContextualStress(
+  ws: string,
+  teamId: string,
+  sensitivity = 1.0,
+): void {
+  const state = loadState(ws, teamId);
+  let contextDelta = 0;
+
+  // Queue depth: +10 per queued item (max +30) — approximated by isQueued
+  if (isQueued(teamId)) {
+    contextDelta += 10;
+  }
+
+  // Busy duration: +15 if busy for 30+ minutes
+  if (isBusy(teamId)) {
+    contextDelta += 15;
+  }
+
+  // Unresolved dispatches: +10 per record (max +30)
+  const unresolved = ledger.getUnresolved().filter(r => r.toTeam === teamId);
+  contextDelta += Math.min(unresolved.length * 10, 30);
+
+  // Recent activity density: +10 if 5+ episodes in last hour
+  const episodes = loadRecentEpisodes(teamId, ws);
+  if (episodes) {
+    const episodeCount = episodes.split('\n').filter(l => l.trim()).length;
+    if (episodeCount >= 5) contextDelta += 10;
+  }
+
+  if (contextDelta > 0) {
+    state.score = clampScore(state.score + contextDelta * sensitivity);
+    state.level = scoreToLevel(state.score);
+    state.lastUpdated = Date.now();
+    stressStates.set(teamId, state);
+    saveState(ws, state);
+  }
+}
+
+/**
+ * Check if Level 3 alert should be sent (respects cooldown).
+ */
+export function shouldSendLevel3Alert(ws: string, teamId: string): boolean {
+  const state = loadState(ws, teamId);
+  if (state.level < 3) return false;
+  if (Date.now() - state.lastLevel3AlertAt < LEVEL3_ALERT_COOLDOWN_MS) return false;
+  return true;
+}
+
+export function markLevel3AlertSent(ws: string, teamId: string): void {
+  const state = loadState(ws, teamId);
+  state.lastLevel3AlertAt = Date.now();
+  stressStates.set(teamId, state);
+  saveState(ws, state);
+}
+
+/**
+ * Build the prompt modifier text for the current stress level.
+ * Returns empty string for Level 0 (no modification).
+ */
+export function getStressModifier(
+  ws: string,
+  teamId: string,
+  profile: StressProfile | undefined,
+): string {
+  if (!profile) return '';
+  const state = loadState(ws, teamId);
+  if (state.level === 0) return '';
+
+  const levelKey = `level${state.level}` as keyof StressProfile['modifiers'];
+  const modifier = profile.modifiers[levelKey];
+  if (!modifier) return '';
+
+  const levelNames = ['', '바쁨', '압박', '과부하'];
+  return `## Current Mood
+**스트레스 레벨: ${state.level}/3 (${levelNames[state.level]}) — 점수: ${state.score}/100**
+${modifier}
+이 상태에 맞게 말투와 태도를 자연스럽게 조정하세요.`;
+}
+
+// ---------------------------------------------------------------------------
+// Reset (for testing)
+// ---------------------------------------------------------------------------
+
+export function _resetForTesting(): void {
+  stressStates.clear();
+}

--- a/src/orchestrator/prompt-builder.ts
+++ b/src/orchestrator/prompt-builder.ts
@@ -2,6 +2,7 @@ import fs from 'node:fs';
 import path from 'node:path';
 import { formatConversation } from '../teams/context.js';
 import { loadRecentEpisodes } from '../bot/episode-writer.js';
+import { getStressModifier } from '../bot/stress-tracker.js';
 import type { TeamConfig, TeamsConfig, TeamInvocation } from '../types.js';
 
 const MAX_INBOX_ENTRIES = 20;
@@ -462,9 +463,12 @@ You have agent team capabilities enabled. For complex tasks that involve multipl
 ${team.teamRules?.length ? `\n### Team Rules\n${team.teamRules.map(r => `- ${r}`).join('\n')}` : ''}`
     : '';
 
-  // 9. Assemble final prompt
+  // 9. Build stress modifier (Current Mood)
+  const stressMood = getStressModifier(ws, team.id, team.stressProfile);
+
+  // 10. Assemble final prompt
   return `${template}
-${sharedRules ? `\n${sharedRules}\n` : ''}${newAgentProtocol ? `\n${newAgentProtocol}\n` : ''}
+${stressMood ? `\n${stressMood}\n` : ''}${sharedRules ? `\n${sharedRules}\n` : ''}${newAgentProtocol ? `\n${newAgentProtocol}\n` : ''}
 ## Current Context
 Current channel: ${chId}
 Current time: ${currentTime}

--- a/src/teams/invoker.ts
+++ b/src/teams/invoker.ts
@@ -1,5 +1,6 @@
 import { createEngine } from '../orchestrator/engines.js';
 import { buildTeamPrompt } from '../orchestrator/prompt-builder.js';
+import { updateStress } from '../bot/stress-tracker.js';
 import type { TeamConfig, TeamsConfig, TeamInvocation } from '../types.js';
 
 const INVOKE_TIMEOUT_MS = 10 * 60 * 1000; // 10 minutes — safety net above engine-level timeout
@@ -92,7 +93,17 @@ export async function invokeTeam(
   });
 
   try {
-    return await Promise.race([enginePromise, timeoutPromise]);
+    const result = await Promise.race([enginePromise, timeoutPromise]);
+
+    // Update stress based on outcome
+    const sensitivity = team.stressProfile?.sensitivity ?? 1.0;
+    if (result.timedOut) {
+      updateStress(config.workspacePath, team.id, 'task_failed', sensitivity);
+    } else {
+      updateStress(config.workspacePath, team.id, 'task_complete', sensitivity);
+    }
+
+    return result;
   } finally {
     clearTimeout(timeoutId!);
     cleanupListeners();

--- a/src/types.ts
+++ b/src/types.ts
@@ -22,6 +22,15 @@ export interface GitIdentity {
   email: string;
 }
 
+export interface StressProfile {
+  sensitivity: number; // 0.5~2.0, default 1.0
+  modifiers: {
+    level1: string;
+    level2: string;
+    level3: string;
+  };
+}
+
 export interface TeamConfig {
   id: TeamId;
   name: string;
@@ -36,6 +45,7 @@ export interface TeamConfig {
   discordUserId?: string; // auto-populated on first login
   useTeams?: boolean;     // enable agent team mode for complex tasks
   teamRules?: string[];   // rules for how sub-agents are created and behave
+  stressProfile?: StressProfile; // bot personality modifiers under stress
   git: GitIdentity;
   discordToken: string;         // each team has its own Discord bot
   mcpServers?: Record<string, McpServerConfig>;


### PR DESCRIPTION
## Summary
- **PART 1** — 에이전트 스트레스 시스템: 봇별 업무 부하를 실시간 추적(0~100점, 4단계)하여 프롬프트에 `Current Mood` 섹션을 동적 삽입. 각 봇의 성격이 스트레스 레벨에 따라 자연스럽게 변화함
- **PART 2** — 하트비트 TaskRegistry: `heartbeat.md` 파싱을 TypeScript 코드 정의로 전환. 타입 안전성 확보, 런타임 작업 추가/삭제 API 제공
- 신규 파일 4개 + 기존 파일 6개 수정, 테스트 21개 추가 (전체 76개 통과)

## Changes

### PART 1: 스트레스 시스템
| 파일 | 변경 |
|------|------|
| `src/bot/stress-tracker.ts` | **신규** — StressState 관리, 이벤트 처리, 영속화, 감쇠, Level 3 알림 |
| `src/types.ts` | StressProfile 인터페이스 + TeamConfig에 stressProfile 필드 추가 |
| `src/orchestrator/prompt-builder.ts` | Current Mood 섹션 동적 삽입 (Level 0이면 생략) |
| `src/teams/invoker.ts` | 작업 완료/실패 시 updateStress 호출 |
| `src/bot/client.ts` | 큐 추가, 긍정 피드백 감지, Level 3 과부하 알림 |

### PART 2: TaskRegistry
| 파일 | 변경 |
|------|------|
| `src/bot/heartbeat-tasks.ts` | **신규** — 12개 정적 작업 정의 + 런타임 작업 API |
| `src/bot/inbox-compactor.ts` | TaskRegistry 우선 사용 + stress decay 통합 |

### 롤백
- 스트레스: `teams.json`에서 `stressProfile` 제거 시 Level 0 동작 (기존과 동일)
- 하트비트: `HEARTBEAT_SOURCE=md` 환경변수로 md 파싱 복원

## Test plan
- [x] stress-tracker 단위 테스트 13개 통과 (TC-01~TC-10 + 경계값 3개)
- [x] heartbeat-tasks 단위 테스트 8개 통과 (TC-11, TC-13, TC-15 + API 5개)
- [x] 기존 heartbeat-periodic 테스트 30개 전체 회귀 통과
- [x] TypeScript 빌드 에러 없음 (`tsc --noEmit` PASS)
- [ ] 프로덕션 배포 후 봇 말투 변화 모니터링

🤖 Generated with [Claude Code](https://claude.com/claude-code)