### PR TITLE
fix: cooldown Maps 메모리 누수 수정 및 중복 시작 방어

### DIFF
--- a/src/bot/__tests__/cooldown-cleanup.test.ts
+++ b/src/bot/__tests__/cooldown-cleanup.test.ts
@@ -1,0 +1,80 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+// Mock concurrency module before importing the module under test
+vi.mock('../../teams/concurrency.js', () => ({
+  isBusy: vi.fn(() => false),
+  isQueued: vi.fn(() => false),
+}));
+
+vi.mock('../../utils/haiku.js', () => ({ runHaiku: vi.fn() }));
+vi.mock('../../utils/fs.js', () => ({ atomicWriteSync: vi.fn() }));
+vi.mock('../../teams/dispatch-ledger.js', () => ({
+  ledger: { getUnresolved: vi.fn(() => []), resolveById: vi.fn() },
+}));
+vi.mock('../../teams/context.js', () => ({ addMessage: vi.fn() }));
+vi.mock('../client.js', () => ({ newChain: vi.fn() }));
+vi.mock('../heartbeat-tasks.js', () => ({ toHeartbeatTasks: vi.fn(() => []) }));
+vi.mock('../stress-tracker.js', () => ({ decayAll: vi.fn() }));
+
+import { purgeExpiredCooldowns, _cooldownState } from '../inbox-compactor.js';
+
+describe('purgeExpiredCooldowns', () => {
+  beforeEach(() => {
+    _cooldownState.pendingTaskCooldowns.clear();
+    _cooldownState.followUpCooldowns.clear();
+    _cooldownState.nudgeCounts.clear();
+  });
+
+  it('should not purge entries that are still within cooldown window', () => {
+    _cooldownState.pendingTaskCooldowns.set('team-a', Date.now());
+    _cooldownState.followUpCooldowns.set('team-b', Date.now());
+
+    const purged = purgeExpiredCooldowns();
+
+    expect(purged).toBe(0);
+    expect(_cooldownState.pendingTaskCooldowns.size).toBe(1);
+    expect(_cooldownState.followUpCooldowns.size).toBe(1);
+  });
+
+  it('should purge expired pendingTaskCooldowns entries (2h+)', () => {
+    const twoHoursAgo = Date.now() - 2 * 60 * 60_000 - 1;
+    _cooldownState.pendingTaskCooldowns.set('team-expired', twoHoursAgo);
+    _cooldownState.pendingTaskCooldowns.set('team-fresh', Date.now());
+
+    const purged = purgeExpiredCooldowns();
+
+    expect(purged).toBe(1);
+    expect(_cooldownState.pendingTaskCooldowns.has('team-expired')).toBe(false);
+    expect(_cooldownState.pendingTaskCooldowns.has('team-fresh')).toBe(true);
+  });
+
+  it('should purge expired followUpCooldowns entries (30m+)', () => {
+    const thirtyMinAgo = Date.now() - 30 * 60_000 - 1;
+    _cooldownState.followUpCooldowns.set('team-expired', thirtyMinAgo);
+    _cooldownState.followUpCooldowns.set('team-fresh', Date.now());
+
+    const purged = purgeExpiredCooldowns();
+
+    expect(purged).toBe(1);
+    expect(_cooldownState.followUpCooldowns.has('team-expired')).toBe(false);
+    expect(_cooldownState.followUpCooldowns.has('team-fresh')).toBe(true);
+  });
+
+  it('should purge from both Maps in a single call', () => {
+    const old = Date.now() - 3 * 60 * 60_000; // 3 hours ago
+    _cooldownState.pendingTaskCooldowns.set('a', old);
+    _cooldownState.pendingTaskCooldowns.set('b', old);
+    _cooldownState.followUpCooldowns.set('c', old);
+
+    const purged = purgeExpiredCooldowns();
+
+    expect(purged).toBe(3);
+    expect(_cooldownState.pendingTaskCooldowns.size).toBe(0);
+    expect(_cooldownState.followUpCooldowns.size).toBe(0);
+  });
+
+  it('should return 0 when Maps are empty', () => {
+    const purged = purgeExpiredCooldowns();
+    expect(purged).toBe(0);
+  });
+});

--- a/src/bot/inbox-compactor.ts
+++ b/src/bot/inbox-compactor.ts
@@ -244,6 +244,41 @@ function setPendingTaskCooldown(teamId: string): void {
   pendingTaskCooldowns.set(teamId, Date.now());
 }
 
+/**
+ * Purge expired entries from cooldown/counter Maps to prevent unbounded growth.
+ * Called periodically by a cleanup timer.
+ */
+export function purgeExpiredCooldowns(): number {
+  const now = Date.now();
+  let purged = 0;
+
+  for (const [teamId, ts] of pendingTaskCooldowns) {
+    if (now - ts >= PENDING_TASK_COOLDOWN_MS) {
+      pendingTaskCooldowns.delete(teamId);
+      purged++;
+    }
+  }
+
+  for (const [teamId, ts] of followUpCooldowns) {
+    if (now - ts >= FOLLOW_UP_COOLDOWN_MS) {
+      followUpCooldowns.delete(teamId);
+      purged++;
+    }
+  }
+
+  if (purged > 0) {
+    console.log(`[cooldown-cleanup] Purged ${purged} expired entries (pending=${pendingTaskCooldowns.size}, followUp=${followUpCooldowns.size}, nudge=${nudgeCounts.size})`);
+  }
+  return purged;
+}
+
+/** @internal — test-only access to cooldown state */
+export const _cooldownState = {
+  get pendingTaskCooldowns() { return pendingTaskCooldowns; },
+  get followUpCooldowns() { return followUpCooldowns; },
+  get nudgeCounts() { return nudgeCounts; },
+};
+
 // ---------------------------------------------------------------------------
 // Leader heartbeat — haiku triage → leader self-invoke
 // ---------------------------------------------------------------------------
@@ -743,7 +778,13 @@ export function startInboxCompactor(
   env: EnvConfig,
   triggerInvocation: InvocationHandler,
 ): void {
-  console.log('[inbox-compactor] Started: fs.watch(immediate) + queue-drain(15s) + heartbeat(3m/fallback) + follow-up(2m) + pending(60s) + digest(24h)');
+  // Guard against double-start — clean up existing timers first
+  if (activeTimers.length > 0) {
+    console.warn('[inbox-compactor] Already running — stopping existing instance before restart');
+    stopInboxCompactor();
+  }
+
+  console.log('[inbox-compactor] Started: fs.watch(immediate) + queue-drain(15s) + heartbeat(3m/fallback) + follow-up(2m) + pending(60s) + cooldown-cleanup(10m) + digest(24h)');
 
   const leaderTeam = Object.values(config.teams).find(t => t.isLeader);
   if (!leaderTeam) {
@@ -852,6 +893,9 @@ export function startInboxCompactor(
       console.error(`[pending-task] Unhandled error: ${err}`);
     });
   }, PENDING_TASK_INTERVAL_MS));
+
+  // Cooldown cleanup: purge expired entries every 10 minutes
+  activeTimers.push(setInterval(purgeExpiredCooldowns, 10 * 60_000));
 
   // Daily digest: every 24 hours (first run after 1 hour)
   activeTimers.push(setTimeout(() => {


### PR DESCRIPTION
## Summary
- `pendingTaskCooldowns`, `followUpCooldowns` Map에 만료된 엔트리가 삭제되지 않고 영구 잔류하는 메모리 누수 수정
- 10분 주기 `purgeExpiredCooldowns` 타이머를 추가하여 만료 엔트리 자동 정리
- `startInboxCompactor` 중복 호출 시 기존 타이머가 누적되는 문제 방어 (호출 시 기존 인스턴스 정리)
- `purgeExpiredCooldowns` 단위 테스트 5건 추가

## Test plan
- [x] 전체 테스트 81개 통과 확인
- [x] cooldown-cleanup 테스트 5개 신규 추가 및 통과
- [ ] 장시간 운행 후 Map 사이즈 모니터링

🤖 Generated with [Claude Code](https://claude.com/claude-code)