### PR TITLE
fix: appendToInbox race condition 수정

### DIFF
--- a/src/bot/__tests__/inbox-writer.test.ts
+++ b/src/bot/__tests__/inbox-writer.test.ts
@@ -1,0 +1,131 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import fs from 'node:fs';
+import path from 'node:path';
+import os from 'node:os';
+import { appendToInbox, clearInbox, _resetInboxQueue } from '../inbox-writer.js';
+
+describe('inbox-writer', () => {
+  let tmpDir: string;
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'inbox-test-'));
+    _resetInboxQueue();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  describe('appendToInbox', () => {
+    it('writes a message to the inbox file', async () => {
+      const promise = appendToInbox('team1', 'Alice', 'Hello world', tmpDir, 'ch123');
+      // Let the microtask queue flush (processInboxWriteQueue runs via Promise)
+      await vi.advanceTimersByTimeAsync(0);
+      await promise;
+
+      const file = path.resolve(tmpDir, '.mococo/inbox/team1.md');
+      const content = fs.readFileSync(file, 'utf-8');
+      expect(content).toContain('Alice: Hello world');
+      expect(content).toContain('#ch:ch123');
+    });
+
+    it('flattens multi-line content', async () => {
+      const promise = appendToInbox('team1', 'Bob', 'line1\nline2\r\nline3', tmpDir, 'ch1');
+      await vi.advanceTimersByTimeAsync(0);
+      await promise;
+
+      const file = path.resolve(tmpDir, '.mococo/inbox/team1.md');
+      const content = fs.readFileSync(file, 'utf-8');
+      expect(content).toContain('Bob: line1 line2 line3');
+      // Should be a single line
+      expect(content.trim().split('\n')).toHaveLength(1);
+    });
+
+    it('queues multiple writes sequentially', async () => {
+      const p1 = appendToInbox('team1', 'A', 'msg1', tmpDir, 'ch1');
+      const p2 = appendToInbox('team1', 'B', 'msg2', tmpDir, 'ch1');
+      const p3 = appendToInbox('team1', 'C', 'msg3', tmpDir, 'ch1');
+      await vi.advanceTimersByTimeAsync(0);
+      await Promise.all([p1, p2, p3]);
+
+      const file = path.resolve(tmpDir, '.mococo/inbox/team1.md');
+      const lines = fs.readFileSync(file, 'utf-8').trim().split('\n');
+      expect(lines).toHaveLength(3);
+      expect(lines[0]).toContain('A: msg1');
+      expect(lines[1]).toContain('B: msg2');
+      expect(lines[2]).toContain('C: msg3');
+    });
+
+    it('rejects on timeout when task is cancelled before execution', async () => {
+      // Simulate: task is enqueued but timeout fires before queue processes it
+      // We do this by making the queue busy with a slow task
+      let slowResolve: () => void;
+      const slowPromise = new Promise<void>(r => { slowResolve = r; });
+      vi.spyOn(fs.promises, 'appendFile').mockImplementationOnce(async () => {
+        await slowPromise;
+      });
+
+      // First task blocks the queue
+      const blocking = appendToInbox('team1', 'Slow', 'blocking', tmpDir, 'ch1');
+      await vi.advanceTimersByTimeAsync(0); // Start processing (hits the mock)
+
+      // Second task queued — its timeout will fire while waiting
+      // Attach catch handler immediately to prevent unhandled rejection
+      const waiting = appendToInbox('team2', 'Waiter', 'waiting', tmpDir, 'ch2');
+      const waitingResult = waiting.catch(err => err);
+
+      // Advance 30s — timeout fires for the waiting task
+      await vi.advanceTimersByTimeAsync(30_001);
+
+      // The waiting task should have been rejected by timeout
+      const err = await waitingResult;
+      expect(err).toBeInstanceOf(Error);
+      expect(err.message).toContain('Timed out');
+
+      // Unblock the first task and let it complete
+      vi.spyOn(fs.promises, 'appendFile').mockRestore();
+      slowResolve!();
+      // Use real timer briefly to let the blocking promise settle
+      vi.useRealTimers();
+      await blocking.catch(() => {}); // May resolve or reject depending on mock state
+    });
+
+    it('does not reject after successful write (race condition fix)', async () => {
+      // The key fix: clearTimeout is called when task starts executing,
+      // so a slow but successful write won't be rejected by timeout
+      const promise = appendToInbox('team1', 'User', 'data', tmpDir, 'ch1');
+
+      // Process the task (this clears the timeout)
+      await vi.advanceTimersByTimeAsync(0);
+      await promise;
+
+      // Even if we advance past 30s, no rejection should occur
+      await vi.advanceTimersByTimeAsync(30_001);
+
+      // Verify file was written
+      const file = path.resolve(tmpDir, '.mococo/inbox/team1.md');
+      expect(fs.existsSync(file)).toBe(true);
+    });
+  });
+
+  describe('clearInbox', () => {
+    it('deletes the inbox file', async () => {
+      // Create an inbox file first
+      const promise = appendToInbox('team1', 'X', 'msg', tmpDir, 'ch1');
+      await vi.advanceTimersByTimeAsync(0);
+      await promise;
+
+      const file = path.resolve(tmpDir, '.mococo/inbox/team1.md');
+      expect(fs.existsSync(file)).toBe(true);
+
+      clearInbox('team1', tmpDir);
+      expect(fs.existsSync(file)).toBe(false);
+    });
+
+    it('does not throw for non-existent file', () => {
+      expect(() => clearInbox('nonexistent', tmpDir)).not.toThrow();
+    });
+  });
+});

--- a/src/bot/client.ts
+++ b/src/bot/client.ts
@@ -13,6 +13,7 @@ import { isBusy, isQueued, markBusy, markFree, waitForFree, getStatus } from '..
 import { ledger } from '../teams/dispatch-ledger.js';
 import { hookEvents } from '../server/hook-receiver.js';
 import { processDiscordCommands, stripMemoryBlocks, ResourceRegistry } from './discord-commands.js';
+import { appendToInbox, clearInbox } from './inbox-writer.js';
 import { startInboxCompactor } from './inbox-compactor.js';
 import { startMemoryConsolidator, checkSizeBasedConsolidation } from './memory-consolidator.js';
 import { startImprovementScanner } from './improvement-scanner.js';
@@ -34,111 +35,6 @@ export const teamClients = new Map<string, Client>();
 // Module-level interval tracking to prevent leaks on createBots() re-invocation
 let _msgCleanupInterval: ReturnType<typeof setInterval> | null = null;
 const _cleanupSignalHandlers: (() => void)[] = [];
-
-// ---------------------------------------------------------------------------
-// Inbox helpers — append chat to a team's inbox file for memory processing
-// ---------------------------------------------------------------------------
-
-// cancelled 플래그로 timeout 후 task 실행을 방지하여 race condition 해결
-interface InboxTask {
-  fn: () => Promise<void>;
-  cancelled: boolean;
-}
-
-const inboxWriteQueue: InboxTask[] = [];
-let isProcessingInboxQueue = false;
-let inboxQueueHead = 0;
-
-async function processInboxWriteQueue() {
-  if (isProcessingInboxQueue || inboxQueueHead >= inboxWriteQueue.length) return;
-  isProcessingInboxQueue = true;
-
-  try {
-    while (inboxQueueHead < inboxWriteQueue.length) {
-      const task = inboxWriteQueue[inboxQueueHead];
-      inboxWriteQueue[inboxQueueHead] = null as any; // Release reference for GC
-      inboxQueueHead++;
-      if (task.cancelled) continue; // timeout으로 취소된 task 스킵 (실행 전 1차 확인)
-      try {
-        if (task.cancelled) continue; // 실행 직전 2차 확인 — timeout race condition 방지
-        await task.fn();
-      } catch (err) {
-        console.error('[inbox-queue] Write failed:', err);
-      }
-    }
-  } finally {
-    isProcessingInboxQueue = false;
-    // drain 완료 후 새 항목이 추가되었는지 확인하여 재처리
-    if (inboxQueueHead < inboxWriteQueue.length) {
-      processInboxWriteQueue().catch(err => console.error('[inbox-queue] Drain error:', err));
-    } else {
-      // 완전히 비었을 때만 참조 해제
-      inboxWriteQueue.length = 0;
-      inboxQueueHead = 0;
-    }
-  }
-}
-
-export function appendToInbox(teamId: string, from: string, content: string, workspacePath: string, channelId: string) {
-  return new Promise<void>((resolve, reject) => {
-    let settled = false;
-
-    const timeout = setTimeout(() => {
-      if (settled) return;
-      settled = true;
-      task.cancelled = true;
-      console.warn(`[inbox-queue] Timed out writing to ${teamId} inbox (30s)`);
-      reject(new Error(`[inbox-queue] Timed out writing to ${teamId} inbox`));
-    }, 30_000);
-
-    const task: InboxTask = {
-      fn: async () => {
-        if (task.cancelled || settled) return; // cancelled 플래그 이중 확인 — timeout race condition 방지
-        try {
-          const dir = path.resolve(workspacePath, '.mococo/inbox');
-          fs.mkdirSync(dir, { recursive: true });
-          const file = path.resolve(dir, `${teamId}.md`);
-          const ts = new Date().toISOString().slice(0, 16).replace('T', ' ');
-          // Flatten multi-line content into single line to prevent summarizeInbox parse failures
-          const flat = content.replace(/[\r\n]+/g, ' ').replace(/\s{2,}/g, ' ');
-          if (settled) return; // I/O 직전 재확인 — timeout race condition 방지
-          await fs.promises.appendFile(file, `[${ts} #ch:${channelId}] ${from}: ${flat}\n`);
-          if (settled) {
-            // timeout 이후 write 완료 — 데이터는 기록됐지만 promise는 이미 reject됨
-            console.warn(`[inbox-queue] Write for ${teamId} completed after timeout — data written but promise already rejected`);
-            return;
-          }
-          settled = true;
-          clearTimeout(timeout);
-          resolve();
-        } catch (err) {
-          if (settled) {
-            console.warn(`[inbox-queue] Write for ${teamId} failed after timeout:`, err instanceof Error ? err.message : err);
-            return;
-          }
-          settled = true;
-          clearTimeout(timeout);
-          reject(err);
-        }
-      },
-      cancelled: false,
-    };
-
-    inboxWriteQueue.push(task);
-    processInboxWriteQueue().catch(err => console.error('[inbox-queue] Queue error:', err));
-  });
-}
-
-export function clearInbox(teamId: string, workspacePath: string) {
-  const file = path.resolve(workspacePath, '.mococo/inbox', `${teamId}.md`);
-  try {
-    fs.unlinkSync(file);
-  } catch (err: any) {
-    if (err?.code !== 'ENOENT') {
-      console.error(`[clearInbox] Failed to delete ${file}:`, err);
-    }
-  }
-}
 
 // ---------------------------------------------------------------------------
 // Chain helpers — prevent infinite bot-to-bot loops

--- a/src/bot/inbox-writer.ts
+++ b/src/bot/inbox-writer.ts
@@ -1,0 +1,90 @@
+import fs from 'node:fs';
+import path from 'node:path';
+
+interface InboxTask {
+  fn: () => Promise<void>;
+  cancelled: boolean;
+}
+
+const inboxWriteQueue: InboxTask[] = [];
+let isProcessingInboxQueue = false;
+let inboxQueueHead = 0;
+
+async function processInboxWriteQueue() {
+  if (isProcessingInboxQueue || inboxQueueHead >= inboxWriteQueue.length) return;
+  isProcessingInboxQueue = true;
+
+  try {
+    while (inboxQueueHead < inboxWriteQueue.length) {
+      const task = inboxWriteQueue[inboxQueueHead];
+      inboxWriteQueue[inboxQueueHead] = null as any; // Release reference for GC
+      inboxQueueHead++;
+      if (task.cancelled) continue;
+      try {
+        await task.fn();
+      } catch (err) {
+        console.error('[inbox-queue] Write failed:', err);
+      }
+    }
+  } finally {
+    isProcessingInboxQueue = false;
+    if (inboxQueueHead < inboxWriteQueue.length) {
+      processInboxWriteQueue().catch(err => console.error('[inbox-queue] Drain error:', err));
+    } else {
+      inboxWriteQueue.length = 0;
+      inboxQueueHead = 0;
+    }
+  }
+}
+
+export function appendToInbox(teamId: string, from: string, content: string, workspacePath: string, channelId: string) {
+  return new Promise<void>((resolve, reject) => {
+    const timeoutId = setTimeout(() => {
+      task.cancelled = true;
+      console.warn(`[inbox-queue] Timed out writing to ${teamId} inbox (30s)`);
+      reject(new Error(`[inbox-queue] Timed out writing to ${teamId} inbox`));
+    }, 30_000);
+
+    const task: InboxTask = {
+      fn: async () => {
+        // Clear timeout when task starts executing — prevents "write succeeds but promise rejects" race
+        clearTimeout(timeoutId);
+        if (task.cancelled) return;
+        try {
+          const dir = path.resolve(workspacePath, '.mococo/inbox');
+          fs.mkdirSync(dir, { recursive: true });
+          const file = path.resolve(dir, `${teamId}.md`);
+          const ts = new Date().toISOString().slice(0, 16).replace('T', ' ');
+          // Flatten multi-line content into single line to prevent summarizeInbox parse failures
+          const flat = content.replace(/[\r\n]+/g, ' ').replace(/\s{2,}/g, ' ');
+          await fs.promises.appendFile(file, `[${ts} #ch:${channelId}] ${from}: ${flat}\n`);
+          resolve();
+        } catch (err) {
+          reject(err);
+        }
+      },
+      cancelled: false,
+    };
+
+    inboxWriteQueue.push(task);
+    processInboxWriteQueue().catch(err => console.error('[inbox-queue] Queue error:', err));
+  });
+}
+
+export function clearInbox(teamId: string, workspacePath: string) {
+  const file = path.resolve(workspacePath, '.mococo/inbox', `${teamId}.md`);
+  try {
+    fs.unlinkSync(file);
+  } catch (err: any) {
+    if (err?.code !== 'ENOENT') {
+      console.error(`[clearInbox] Failed to delete ${file}:`, err);
+    }
+  }
+}
+
+/** Reset queue state — for testing only */
+export function _resetInboxQueue() {
+  inboxWriteQueue.length = 0;
+  inboxQueueHead = 0;
+  isProcessingInboxQueue = false;
+}


### PR DESCRIPTION
## Summary
- `appendToInbox`에서 timeout이 `await appendFile` 도중 발생 시 파일은 쓰이지만 promise가 reject되는 race condition 수정
- `clearTimeout`을 task 실행 시작 시점으로 이동하여 race window 제거
- `settled` 플래그 제거 (JS Promise 자체가 double-settlement 무시하므로 불필요)
- 중복 cancelled 체크 4회 → 1회로 단순화
- inbox 로직을 `inbox-writer.ts`로 분리하여 테스트 용이성 확보

## Changes
- **`src/bot/inbox-writer.ts`** (신규): inbox 큐, `appendToInbox`, `clearInbox` 로직 분리
- **`src/bot/client.ts`**: inbox 코드 제거, inbox-writer에서 import
- **`src/bot/__tests__/inbox-writer.test.ts`** (신규): 7개 테스트 (정상 쓰기, 멀티라인 flatten, 큐 순서, timeout, race fix 검증)

## Test plan
- [x] 전체 테스트 83개 통과
- [x] TypeScript 타입체크 통과
- [ ] 체커코코 코드 리뷰

🤖 Generated with [Claude Code](https://claude.com/claude-code)