### PR TITLE
fix. 오픈소스 레포에서 내부 팀 머지 권한 설정 제거

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,7 +4,7 @@ These rules apply to ALL teams. Every Claude process loads this file.
 
 ## Absolute Rules
 
-1. **NEVER merge a PR** — `gh pr merge` is forbidden. Only humans merge. (Exception: Review team can merge Kil-biseo and claude-mococo repos after PASS.)
+1. **NEVER merge a PR** — `gh pr merge` is forbidden. Only humans merge.
 2. **NEVER force push** to main/master branches.
 3. **NEVER delete remote branches** with open PRs.
 4. **NEVER expose secrets** — no .env files, no tokens, no credentials in commits.
@@ -13,7 +13,7 @@ These rules apply to ALL teams. Every Claude process loads this file.
 
 - **Leader, Planning, Design:** Read-only. No file edits, no git push, no PRs.
 - **Backend, Frontend:** Can edit files, commit locally. Cannot push or create PRs.
-- **Review:** Can push branches and create PRs. Can merge Kil-biseo and claude-mococo repos (after PASS).
+- **Review:** Can push branches and create PRs. Cannot merge.
 
 ## Commit Format
 

--- a/README.ko.md
+++ b/README.ko.md
@@ -23,7 +23,7 @@
 | **대장코코** | `leader` | Claude | sonnet | 지휘·조율, 모든 메시지 응답, 하트비트 실행 | 읽기 전용 (파일 편집·git 불가) |
 | **스택코코** | `stack` | Claude | opus | 백엔드 API, DB 설계·구현 | 파일 편집 + 로컬 커밋 (푸시·머지 불가) |
 | **브러쉬코코** | `brush` | Claude | sonnet | UI/UX 구현, Figma 연동 | 파일 편집 + 로컬 커밋 (푸시·머지 불가) |
-| **체커코코** | `checker` | Claude | sonnet | QA, PR 리뷰, 노션 문서화 | 읽기 전용 + Kil-biseo/claude-mococo 레포 PR 머지 가능 |
+| **체커코코** | `checker` | Claude | sonnet | QA, PR 리뷰, 노션 문서화 | 읽기 전용 + PR 푸시·리뷰 가능 |
 
 > 팀 구성은 자유롭게 설계할 수 있습니다. 위는 mococo-corps 기준 예시입니다.
 
@@ -149,7 +149,7 @@ Discord 채널에서 봇에게 말을 걸면 됩니다.
 실제 mococo-corps 권한 구조:
 - **대장코코:** 파일 편집·git push·gh pr 전부 차단. 판단·조율만.
 - **스택코코/브러쉬코코:** 파일 편집·로컬 커밋 가능. push·merge 불가.
-- **체커코코:** 읽기 전용. 단, Kil-biseo/claude-mococo 레포 PR 머지는 조건부 허용.
+- **체커코코:** 읽기 전용 + PR 푸시·리뷰 가능. 머지 권한은 운영 설정에서 별도 관리.
 
 ### 메모리 시스템
 
@@ -244,7 +244,7 @@ Notion MCP를 연동하면 에이전트가 직접 문서를 생성하고 관리�
 |------|--------------|----------------|------------|
 | atom.io | `master` | `staging` | 회장님 |
 | Kil-biseo | `main` | `main` | 체커코코 (리뷰+CI 통과 조건) |
-| claude-mococo | `main` | `main` | 체커코코 (리뷰 PASS 조건) |
+| claude-mococo | `main` | `main` | 회장님 |
 | orbi-advance | `prod` | `prod` | 회장님 |
 
 레포별 정책은 에이전트 성격 파일 내 **레포별 관리 전략** 섹션에 명시합니다.

--- a/README.md
+++ b/README.md
@@ -136,8 +136,8 @@ Controlled per-agent in `teams.json`. The permission value is matched against th
 Typical tiers:
 - **Leader:** Read-only — deny `git push`, `gh pr`, file edits
 - **Backend / Frontend:** Edit files, commit locally — deny `git push`, `gh pr merge`
-- **Reviewer:** Push and open PRs — can merge Kil-biseo and claude-mococo repos after PASS
-- **All agents:** `git push --force main/master` denied globally. `gh pr merge` denied except for Reviewer on Kil-biseo and claude-mococo repos
+- **Reviewer:** Push and open PRs — deny `gh pr merge`
+- **All agents:** `gh pr merge` and `git push --force main/master` denied globally
 
 ### Engines
 

--- a/defaults/shared-rules.md
+++ b/defaults/shared-rules.md
@@ -8,7 +8,7 @@ On conflict: stop → verify → propose alternative → execute after approval.
 {{humanTitle}} > {{leaderName}} > Self. Superiors' instructions always take priority.
 
 ### Absolute Prohibitions
-- PR merge — only {{humanTitle}} can do this (exception: Kil-biseo and claude-mococo repos — review team can merge after PASS)
+- PR merge — only {{humanTitle}} can do this
 - Exposing tokens, passwords, or credentials
 - Tagging your own Discord ID
 

--- a/src/orchestrator/prompt-builder.ts
+++ b/src/orchestrator/prompt-builder.ts
@@ -249,7 +249,7 @@ Example:
 
 ### Policies & Rules
 Example:
-- PR merge is ${humanTitle}-only (exception: review team can merge Kil-biseo and claude-mococo repos)
+- PR merge is ${humanTitle}-only
 - Hotfixes can be autonomous, feature additions need proposal
 
 ### Team Capabilities


### PR DESCRIPTION
## Summary
- PR #75에서 추가된 내부 팀 설정(체커코코 머지 권한)을 오픈소스 레포에서 제거
- 내부 팀 머지 권한 설정은 mococo-corps에서 관리 (이미 `prompts/shared-rules.md`에 반영되어 있음)
- CLAUDE.md, README, defaults/shared-rules.md, prompt-builder.ts 총 5개 파일 원복

## 변경 내용
| 파일 | 변경 |
|------|------|
| `CLAUDE.md` | 체커코코 머지 예외 제거 → 범용 기본값 |
| `README.md` | Reviewer 권한 설명 범용화 |
| `README.ko.md` | 체커코코 권한·머지 담당자 범용화 |
| `defaults/shared-rules.md` | 머지 예외 정책 제거 |
| `prompt-builder.ts` | 장기메모리 예시 문구 범용화 |

## Test plan
- [x] 테스트 102개 전체 통과
- [ ] 봇 재시작 후 내부 팀 설정이 mococo-corps 기준으로만 적용되는지 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)